### PR TITLE
Use a real child injector

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.36-SNAPSHOT
+version=0.0.37-SNAPSHOT

--- a/src/test/java/com/netflix/governator/guice/TestGovernatorGuice.java
+++ b/src/test/java/com/netflix/governator/guice/TestGovernatorGuice.java
@@ -46,7 +46,7 @@ public class TestGovernatorGuice
     @Test
     public void     testAutoBindSingletonVsSingleton() throws Exception
     {
-        final List<Object>  objects = Lists.newArrayList();
+        final List<Object>        objects = Lists.newArrayList();
         final LifecycleListener   listener = new LifecycleListener()
         {
             @Override


### PR DESCRIPTION
Trying to "fake" a child injector was causing duplicate objects. Use a real child injector now. However, this exposed what appears to be a bug in Guice. TypeListeners set in a child injector are ingored. So, I've worked around it with a kludge.
