### PR TITLE
Fix for issue #42

### DIFF
--- a/src/main/java/com/netflix/governator/annotations/Configuration.java
+++ b/src/main/java/com/netflix/governator/annotations/Configuration.java
@@ -40,4 +40,20 @@ public @interface Configuration
      * @return user displayable description of this configuration
      */
     String      documentation() default "";
+
+    /**
+     * If the value of the property defined for this config is not the same or can not be converted to the
+     * required type, setting this to <code>true</code> will ignore such a value. In such a case, the target field
+     * will contain the default value if defined.<br/>
+     * The error during configuration is deemed as a type mismatch if the exception thrown by the {@link ConfigurationProvider}
+     * is one amongst:
+     * <ul>
+     * <li>{@link IllegalArgumentException}</li>
+     * <li>{@link org.apache.commons.configuration.ConversionException}</li>
+     </ul>
+     *
+     * @return <code>true</code> if type mismatch must be ignored. <code>false</code> otherwise. Default value is
+     * <code>false</code>
+     */
+    boolean ignoreTypeMismatch() default false;
 }

--- a/src/test/java/com/netflix/governator/lifecycle/TestConfiguration.java
+++ b/src/test/java/com/netflix/governator/lifecycle/TestConfiguration.java
@@ -16,12 +16,19 @@
 
 package com.netflix.governator.lifecycle;
 
+import com.netflix.governator.configuration.ArchaiusConfigurationProvider;
+import com.netflix.governator.configuration.ConfigurationProvider;
 import com.netflix.governator.configuration.PropertiesConfigurationProvider;
 import com.netflix.governator.lifecycle.mocks.ObjectWithConfig;
+import com.netflix.governator.lifecycle.mocks.ObjectWithIgnoreTypeMismatchConfig;
 import com.netflix.governator.lifecycle.mocks.PreConfigurationChange;
 import com.netflix.governator.lifecycle.mocks.SubclassedObjectWithConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 public class TestConfiguration
@@ -97,5 +104,53 @@ public class TestConfiguration
         Assert.assertEquals(obj.aLong, 200);
         Assert.assertEquals(obj.aDouble, 300.4);
         Assert.assertEquals(obj.aString, "a is a");
+    }
+
+    @Test
+    public void     testConfigTypeMismatchWithPropProvider() throws Exception
+    {
+        Properties properties = new Properties();
+        properties.setProperty("test.b", "20");
+        properties.setProperty("test.i", "foo");
+        properties.setProperty("test.l", "bar");
+        properties.setProperty("test.d", "zar");
+        properties.setProperty("test.s", "a is a");
+        properties.setProperty("test.dt", "dar");
+
+        testTypeMismatch(new PropertiesConfigurationProvider(properties));
+    }
+
+    @Test
+    public void     testConfigTypeMismatchWithArchaius() throws Exception
+    {
+        Map<String, String> properties = new HashMap<String, String>();
+        properties.put("test.b", "20");
+        properties.put("test.i", "foo");
+        properties.put("test.l", "bar");
+        properties.put("test.d", "zar");
+        properties.put("test.s", "a is a");
+        properties.put("test.dt", "dar");
+
+        testTypeMismatch(new ArchaiusConfigurationProvider(properties));
+    }
+
+    private void testTypeMismatch(ConfigurationProvider provider) throws Exception {
+        LifecycleManagerArguments arguments = new LifecycleManagerArguments();
+        arguments.getConfigurationProvider().add(provider);
+
+        LifecycleManager manager = new LifecycleManager(arguments);
+
+        ObjectWithIgnoreTypeMismatchConfig obj = new ObjectWithIgnoreTypeMismatchConfig();
+        ObjectWithIgnoreTypeMismatchConfig nonGovernatedSample = new ObjectWithIgnoreTypeMismatchConfig();
+        nonGovernatedSample.aDate = new Date(obj.aDate.getTime());
+        manager.add(obj);
+        manager.start();
+
+
+        Assert.assertEquals(obj.aBool, nonGovernatedSample.aBool);
+        Assert.assertEquals(obj.anInt, nonGovernatedSample.anInt);
+        Assert.assertEquals(obj.aLong, nonGovernatedSample.aLong);
+        Assert.assertEquals(obj.aDouble, nonGovernatedSample.aDouble);
+        Assert.assertEquals(obj.aDate, nonGovernatedSample.aDate);
     }
 }

--- a/src/test/java/com/netflix/governator/lifecycle/mocks/ObjectWithIgnoreTypeMismatchConfig.java
+++ b/src/test/java/com/netflix/governator/lifecycle/mocks/ObjectWithIgnoreTypeMismatchConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.netflix.governator.lifecycle.mocks;
+
+import com.netflix.governator.annotations.Configuration;
+
+import java.util.Date;
+
+public class ObjectWithIgnoreTypeMismatchConfig
+{
+    @Configuration(value = "test.b", documentation = "this is a boolean", ignoreTypeMismatch = true)
+    public boolean   aBool = false;
+
+    @Configuration(value="test.i", ignoreTypeMismatch = true)
+    public int       anInt = 1;
+
+    @Configuration(value = "test.l", ignoreTypeMismatch = true)
+    public long      aLong = 2;
+
+    @Configuration(value = "test.d", ignoreTypeMismatch = true)
+    public double    aDouble = 3.4;
+
+    @Configuration(value = "test.dt", ignoreTypeMismatch = true)
+    public Date     aDate = new Date();
+}


### PR DESCRIPTION
Introduce a parameter ignoreTypeMismatch in @Configuration to ignore type mismatch.

This breaks backward compatibility with the Date type of configuration keys. Currently, the date type mismatch is always ignored. There wasn't a way to keep this parameter's behavior consistent across all data types without breaking this compatibility.
