### PR TITLE
StackOverflowError in InternalLifecycleModule.warmUpIsInDag()

### DIFF
--- a/src/test/java/com/netflix/governator/lifecycle/CircularDAG.java
+++ b/src/test/java/com/netflix/governator/lifecycle/CircularDAG.java
@@ -1,0 +1,62 @@
+package com.netflix.governator.lifecycle;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+import com.google.inject.Injector;
+import com.netflix.governator.annotations.WarmUp;
+import com.netflix.governator.guice.LifecycleInjector;
+
+/**
+ * There is a infinite recursion in InternalLifecycleModule.warmUpIsInDag(InternalLifecycleModule.java:150)
+ * and InternalLifecycleModule.warmUpIsInDag(InternalLifecycleModule.java:171) that will ultimately lead to
+ * an StackOverflowError.
+ */
+public class CircularDAG {
+
+  @Singleton
+  public static class A {
+
+    @Inject
+    private B b;
+  }
+
+  @Singleton
+  public static class B {
+
+    @Inject
+    private A a;
+  }
+
+  @Singleton
+  public static class Service {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    private A a;
+
+    @WarmUp
+    public void connect() {
+      log.info("connect");
+    }
+
+    @PreDestroy
+    public void disconnect() {
+      log.info("disconnect");
+    }
+  }
+
+  @Test
+  public void circle() throws StackOverflowError, Exception {
+    Injector injector = LifecycleInjector.builder().createInjector();
+
+    injector.getInstance(Service.class);
+    LifecycleManager manager = injector.getInstance(LifecycleManager.class);
+    manager.start();
+  }
+}


### PR DESCRIPTION
This Unit Test (fix to follow) demonstrates an infinite recursion in warmUpIsInDag() that leads untimely to a StackOverflowError.

```
java.lang.StackOverflowError
    at java.util.AbstractList$ListItr.<init>(AbstractList.java:377)
    at java.util.AbstractList.listIterator(AbstractList.java:315)
    at java.util.AbstractList.listIterator(AbstractList.java:284)
    at java.util.AbstractList.equals(AbstractList.java:502)
    at java.util.HashMap.get(HashMap.java:305)
    at java.lang.reflect.Proxy.getProxyClass(Proxy.java:426)
    at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:581)
    at sun.reflect.annotation.AnnotationParser.annotationForMap(AnnotationParser.java:239)
    at sun.reflect.annotation.AnnotationParser.parseAnnotation(AnnotationParser.java:229)
    at sun.reflect.annotation.AnnotationParser.parseAnnotations2(AnnotationParser.java:69)
    at sun.reflect.annotation.AnnotationParser.parseAnnotations(AnnotationParser.java:52)
    at java.lang.reflect.Field.declaredAnnotations(Field.java:1014)
    at java.lang.reflect.Field.getAnnotation(Field.java:1000)
    at com.google.inject.spi.InjectionPoint.getAtInject(InjectionPoint.java:466)
    at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:651)
    at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:356)
    at com.netflix.governator.guice.InternalLifecycleModule.getMethodInjectionPoints(InternalLifecycleModule.java:183)
    at com.netflix.governator.guice.InternalLifecycleModule.warmUpIsInDag(InternalLifecycleModule.java:150)
    at com.netflix.governator.guice.InternalLifecycleModule.warmUpIsInDag(InternalLifecycleModule.java:171)
...
```
