### PR TITLE
deprecated ill-defined createInjector() API that has bad side effect of ...

### DIFF
--- a/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilder.java
+++ b/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilder.java
@@ -16,12 +16,13 @@
 
 package com.netflix.governator.guice;
 
+import java.util.Collection;
+
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Stage;
 import com.netflix.governator.annotations.AutoBindSingleton;
 import com.netflix.governator.lifecycle.ClasspathScanner;
-import java.util.Collection;
 
 /**
  * Builder for a {@link LifecycleInjector}
@@ -130,6 +131,13 @@ public interface LifecycleInjectorBuilder
      * {@link LifecycleInjector#createInjector()}
      *
      * @return Guice injector
+     * 
+     * @deprecated this API creates the "main" child injector.
+     * but it has the side effect of calling build() method 
+     * that will create a new LifecycleInjector.
+     * Instead, you should just build() LifecycleInjector object.
+     * then call LifecycleInjector.createInjector() directly.
      */
+    @Deprecated
     public Injector createInjector();
 }

--- a/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilderImpl.java
+++ b/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilderImpl.java
@@ -16,15 +16,16 @@
 
 package com.netflix.governator.guice;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Stage;
 import com.netflix.governator.lifecycle.ClasspathScanner;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 
 class LifecycleInjectorBuilderImpl implements LifecycleInjectorBuilder
 {
@@ -124,6 +125,7 @@ class LifecycleInjectorBuilderImpl implements LifecycleInjectorBuilder
     }
 
     @Override
+    @Deprecated
     public Injector createInjector()
     {
         return build().createInjector();


### PR DESCRIPTION
...creating a new LifecycleInjector object
