### PR TITLE
Possible solutions for "Configuring multiple instances of same object" Issue #56

### DIFF
--- a/src/main/java/com/netflix/governator/annotations/ConfigurationVariable.java
+++ b/src/main/java/com/netflix/governator/annotations/ConfigurationVariable.java
@@ -1,0 +1,13 @@
+package com.netflix.governator.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface ConfigurationVariable {
+    String name();
+}

--- a/src/main/java/com/netflix/governator/configuration/KeyParser.java
+++ b/src/main/java/com/netflix/governator/configuration/KeyParser.java
@@ -18,16 +18,21 @@ package com.netflix.governator.configuration;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import java.util.Map;
 
 public class KeyParser
 {
+    public static List<ConfigurationKeyPart> parse(String raw) {
+        return parse(raw, null);
+    }
+    
     /**
      * Parse a key into parts
      *
      * @param raw the key
      * @return parts
      */
-    public static List<ConfigurationKeyPart> parse(String raw)
+    public static List<ConfigurationKeyPart> parse(String raw, Map<String, String> contextOverrides)
     {
         List<ConfigurationKeyPart> parts = Lists.newArrayList();
 
@@ -52,7 +57,13 @@ public class KeyParser
             startIndex += 2;
             if ( startIndex < endIndex )
             {
-                parts.add(new ConfigurationKeyPart(raw.substring(startIndex, endIndex), true));
+                String name = raw.substring(startIndex, endIndex);
+                if (contextOverrides != null && contextOverrides.containsKey(name)) {
+                    parts.add(new ConfigurationKeyPart(contextOverrides.get(name), false));
+                }
+                else {
+                    parts.add(new ConfigurationKeyPart(name, true));
+                }
             }
             caret = endIndex + 1;
         }

--- a/src/main/java/com/netflix/governator/lifecycle/ConfigurationProcessor.java
+++ b/src/main/java/com/netflix/governator/lifecycle/ConfigurationProcessor.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.util.Date;
+import java.util.Map;
 
 class ConfigurationProcessor
 {
@@ -43,11 +44,11 @@ class ConfigurationProcessor
         this.configurationDocumentation = configurationDocumentation;
     }
 
-    void assignConfiguration(Object obj, Field field) throws Exception
+    void assignConfiguration(Object obj, Field field, Map<String, String> contextOverrides) throws Exception
     {
         Configuration configuration = field.getAnnotation(Configuration.class);
         String configurationName = configuration.value();
-        ConfigurationKey key = new ConfigurationKey(configurationName, KeyParser.parse(configurationName));
+        ConfigurationKey key = new ConfigurationKey(configurationName, KeyParser.parse(configurationName, contextOverrides));
 
         Object value = null;
 

--- a/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
+++ b/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
@@ -27,6 +27,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.netflix.governator.annotations.Configuration;
+import com.netflix.governator.annotations.ConfigurationVariable;
 import com.netflix.governator.annotations.PreConfiguration;
 import com.netflix.governator.configuration.ConfigurationDocumentation;
 import com.netflix.governator.configuration.ConfigurationProvider;
@@ -317,10 +318,18 @@ public class LifecycleManager implements Closeable
         }
 
         setState(obj, LifecycleState.SETTING_CONFIGURATION);
+        Map<String, String> overrides = Maps.newHashMap();
+        for ( Field variableField : methods.fieldsFor(ConfigurationVariable.class)) {
+            ConfigurationVariable annot = variableField.getAnnotation(ConfigurationVariable.class);
+            if (annot != null) {
+                overrides.put(annot.name(), variableField.get(obj).toString());
+            }
+        }
+        
         ConfigurationProcessor configurationProcessor = new ConfigurationProcessor(configurationProvider, configurationDocumentation);
         for ( Field configurationField : methods.fieldsFor(Configuration.class) )
         {
-            configurationProcessor.assignConfiguration(obj, configurationField);
+            configurationProcessor.assignConfiguration(obj, configurationField, overrides);
         }
 
         setState(obj, LifecycleState.SETTING_RESOURCES);

--- a/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
+++ b/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.netflix.governator.annotations.Configuration;
+import com.netflix.governator.annotations.ConfigurationVariable;
 import com.netflix.governator.annotations.PreConfiguration;
 import com.netflix.governator.annotations.WarmUp;
 import org.slf4j.Logger;
@@ -68,6 +69,7 @@ public class LifecycleMethods
         fieldAnnotationsBuilder.add(Configuration.class);
         fieldAnnotationsBuilder.add(Resource.class);
         fieldAnnotationsBuilder.add(Resources.class);
+        fieldAnnotationsBuilder.add(ConfigurationVariable.class);
         fieldAnnotations = fieldAnnotationsBuilder.build();
 
         ImmutableSet.Builder<Class<? extends Annotation>> classAnnotationsBuilder = ImmutableSet.builder();

--- a/src/test/java/com/netflix/governator/lifecycle/TestConfiguration.java
+++ b/src/test/java/com/netflix/governator/lifecycle/TestConfiguration.java
@@ -22,6 +22,7 @@ import com.netflix.governator.configuration.ConfigurationOwnershipPolicies;
 import com.netflix.governator.configuration.ConfigurationProvider;
 import com.netflix.governator.configuration.PropertiesConfigurationProvider;
 import com.netflix.governator.lifecycle.mocks.ObjectWithConfig;
+import com.netflix.governator.lifecycle.mocks.ObjectWithConfigVariable;
 import com.netflix.governator.lifecycle.mocks.ObjectWithDynamicConfig;
 import com.netflix.governator.lifecycle.mocks.ObjectWithIgnoreTypeMismatchConfig;
 import com.netflix.governator.lifecycle.mocks.PreConfigurationChange;
@@ -109,6 +110,33 @@ public class TestConfiguration
         Assert.assertEquals(obj.aString, "a is a");
     }
 
+    @Test
+    public void     testConfigWithVariable() throws Exception 
+    {
+        Properties properties = new Properties();
+        properties.setProperty("test.b", "true");
+        properties.setProperty("test.i", "101");
+        properties.setProperty("test.l", "201");
+        properties.setProperty("test.d", "301.4");
+        properties.setProperty("test.s", "b is b");
+        properties.setProperty("test.dt", "1965-10-06");
+
+        LifecycleManagerArguments   arguments = new LifecycleManagerArguments();
+        arguments.getConfigurationProvider().add(new PropertiesConfigurationProvider(properties));
+
+        LifecycleManager            manager = new LifecycleManager(arguments);
+
+        ObjectWithConfigVariable obj = new ObjectWithConfigVariable("test");        
+        manager.add(obj);
+        manager.start();
+
+        Assert.assertEquals(obj.aBool, true);
+        Assert.assertEquals(obj.anInt, 101);
+        Assert.assertEquals(obj.aLong, 201);
+        Assert.assertEquals(obj.aDouble, 301.4);
+        Assert.assertEquals(obj.aString, "b is b");
+    }
+    
     @Test
     public void     testConfigTypeMismatchWithPropProvider() throws Exception
     {

--- a/src/test/java/com/netflix/governator/lifecycle/mocks/ObjectWithConfigVariable.java
+++ b/src/test/java/com/netflix/governator/lifecycle/mocks/ObjectWithConfigVariable.java
@@ -1,0 +1,33 @@
+package com.netflix.governator.lifecycle.mocks;
+
+import java.util.Date;
+
+import com.netflix.governator.annotations.Configuration;
+import com.netflix.governator.annotations.ConfigurationVariable;
+
+public class ObjectWithConfigVariable {
+    @ConfigurationVariable(name="name")
+    private final String name;
+    
+    @Configuration(value = "${name}.b", documentation = "this is a boolean")
+    public boolean aBool = false;
+
+    @Configuration("${name}.i")
+    public int anInt = 1;
+
+    @Configuration("${name}.l")
+    public long aLong = 2;
+
+    @Configuration("${name}.d")
+    public double aDouble = 3.4;
+
+    @Configuration("${name}.s")
+    public String aString = "test";
+
+    @Configuration("${name}.dt")
+    public Date aDate = null;
+    
+    public ObjectWithConfigVariable(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Make a field value available as a configuration parameter so it can be used to simplify configuration of multiple objects of the same class using different configuration names.  This is much easier to code that using PreConfiguration.
