### PR TITLE
Governator bootstrap based servlet subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,14 @@ project(':governator-test-junit') {
     
     }
 }
+
+project(':governator-servlet') {
+    apply plugin: 'java'
+    dependencies {
+        compile     project(':governator')
+        compile     'javax.servlet:servlet-api:2.5'
+        compile     'com.google.inject.extensions:guice-servlet:3.0'
+        compile     "junit:junit-dep:4.+"
+    
+    }
+}

--- a/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/DefaultServletContextListener.java
+++ b/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/DefaultServletContextListener.java
@@ -1,0 +1,31 @@
+package com.netflix.governator.guice.servlet;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import com.netflix.governator.guice.lazy.LazySingleton;
+
+/**
+ * Default no-op implementation of a ServletContextListener within the context of
+ * Guice.
+ * 
+ * @author elandau
+ *
+ */
+@LazySingleton
+public final class DefaultServletContextListener implements ServletContextListener {
+    /**
+     * Called after the injector and all eager singletons have been created and
+     * LifecycleManager.start() was called.  
+     */
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+    }
+
+    /**
+     * Called before LifecycleManager.shutdown() is called.
+     */
+    @Override
+    public void contextDestroyed(final ServletContextEvent event) {
+    }
+}

--- a/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
+++ b/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
@@ -1,0 +1,125 @@
+package com.netflix.governator.guice.servlet;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.servlet.GuiceServletContextListener;
+import com.netflix.governator.guice.LifecycleInjector;
+import com.netflix.governator.lifecycle.LifecycleManager;
+
+/**
+ * An extension of {@link GuiceServletContextListener} which integrates with Governator's bootstrap 
+ * mechanism.  This implementation drives start/shutdown of LifecycleManager through the 
+ * ServletContextListener's contextInitialize/contextDestroyed events.  
+ * 
+ *In order for this to work you must have the following entries in your web.xml.
+ *
+ <PRE>
+     &lt;context-param&gt;
+       &lt;param-name&gt;governator.bootstrap.class&lt;/param-name&gt;
+       &lt;param-value&gt;com.myorg.MyBootstrap&lt;/param-value&gt;
+     &lt;/context-param&gt;
+  
+     &lt;filter&gt;
+         &lt;filter-name&gt;guiceFilter&lt;/filter-name&gt;
+         &lt;filter-class&gt;com.google.inject.servlet.GuiceFilter&lt;/filter-class&gt;
+     &lt;/filter&gt;
+
+     &lt;filter-mapping&gt;
+         &lt;filter-name&gt;guiceFilter&lt;/filter-name&gt;
+         &lt;url-pattern&gt;/*&lt;/url-pattern&gt;
+     &lt;/filter-mapping&gt;
+
+     &lt;listener&gt;
+         &lt;listener-class&gt;com.netflix.governator.guice.servlet.GovernatorServletContextListener&lt;/listener-class&gt;
+     &lt;/listener&gt;
+
+ </PRE>
+ *
+ * This implementation uses Governator's annotation based bootstrap model to 
+ * pull in all the bindings for the server.  A bootstrap class must therefore be
+ * specified in a configuration.  The default implementation expects a servlet
+ * context attribute called 'bootstrapClass' in web.xml. 
+ *
+ * @author Eran Landau
+ */
+public class GovernatorServletContextListener extends GuiceServletContextListener {
+    protected static final Logger LOG = LoggerFactory.getLogger(GovernatorServletContextListener.class);
+
+    private static final String BOOTSTRAP_CLASS = "governator.bootstrap.class";
+
+    private Class<?> bootstrapClass;
+    
+    private ServletContextListener delegate;
+    
+    private LifecycleManager lifecycleManager;
+    
+    @Override
+    protected Injector getInjector() {
+        Injector injector = LifecycleInjector.bootstrap(bootstrapClass);
+        this.lifecycleManager = injector.getInstance(LifecycleManager.class);
+        if (injector.getExistingBinding(Key.get(ServletContextListener.class)) != null) {
+            this.delegate = injector.getInstance(ServletContextListener.class);
+        }
+        return injector;
+    }
+    
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        try {
+            bootstrapClass = getBootstrapClass(servletContextEvent.getServletContext());
+            
+            super.contextInitialized(servletContextEvent);
+            try {
+                lifecycleManager.start();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to start LifecycleManager", e);
+            }
+            if (delegate != null) {
+                delegate.contextInitialized(servletContextEvent);
+            }
+        }
+        catch (Throwable t) {
+            LOG.error("Failed to start server", t);
+            System.exit(1);
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        if (delegate != null) {
+            delegate.contextDestroyed(servletContextEvent);
+        }
+        if (lifecycleManager != null) {
+            lifecycleManager.close();
+        }
+        super.contextDestroyed(servletContextEvent);
+    }
+    
+    /**
+     * Default implementation for getting the bootstrap class from the ServletContext in the web.xml
+     * or from system properties
+     * 
+     * @param servletContext
+     * @return
+     * @throws ClassNotFoundException
+     */
+    protected Class<?> getBootstrapClass(ServletContext servletContext) throws ClassNotFoundException {
+        String bootstrapClassName = servletContext.getInitParameter(BOOTSTRAP_CLASS).toString();
+        if (bootstrapClassName == null) {
+            bootstrapClassName = System.getProperty(BOOTSTRAP_CLASS);
+        }
+        
+        if (bootstrapClassName == null) {
+            throw new RuntimeException("Unable to determine the bootstrap class name");
+        }
+                
+        return Class.forName(bootstrapClassName);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name='governator'
 include 'governator-core'
+include 'governator-servlet'
 include 'governator-test-junit'
 project(':governator-core').name = 'governator'


### PR DESCRIPTION
Integrate GuiceServletContextListener into Governator's bootstrap mechanism.  This integration will drive LifecycleManager start()/close() from the ServletContext events.  In addition it provides a mechanism to hook into the ServletContextListener via a custom ServletContextListener that is created within the context of Guice and can therefore inject dependencies.

Example,

web.xml

``` xml
<context-param>
  <param-name>governator.bootstrap.class</param-name>
  <param-value>com.myorg.MyBootstrap</param-value>
</context-param>

<filter>
    <filter-name>guiceFilter</filter-name>
    <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
</filter>

<filter-mapping>
    <filter-name>guiceFilter</filter-name>
    <url-pattern>/*</url-pattern>
</filter-mapping>

<listener>
    <listener-class>com.netflix.governator.guice.servlet.GovernatorServletContextListener</listener-class>
</listener>
```

This is the Governator bootstrap enabled class.

``` java
@Modules(include={SomeServiceModule.class})
public class MyBootstrap extends AbstractModule {
    protected void configure() { 
        bind(ServletContextListener.class).to(MyServletContextListener.class);
    }
}
```

This is the custom ServletContextListener that can have dependencies injected into it.

``` java
@FineGrainedLazySingleton
public class MyServletContextListener implements ServletContextListener {
    private final SomeService service;

    @Inject
    public MyServletContextListener(SomeService service) {
        this.service = service;
    }
    @Override
    public void contextInitialized(final ServletContextEvent event) {
        service.doSomeStartupTask();
    }
}
```
