### PR TITLE
Log each use of AutoBindSingleton

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/guice/ModuleListBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/guice/ModuleListBuilder.java
@@ -79,13 +79,6 @@ public class ModuleListBuilder {
                     return null;
                 }
                 
-                // TODO: Guard from circular dependencies
-                if (replacements.containsKey(type)) {
-                    Class<? extends Module> replacement = replacements.get(type);
-                    LOG.info("Replacing module '" + type + "' with '" + replacement.getClass().getName() + "'");
-                    return includes.get(replacements.get(type)).getInstance(injector);
-                }
-                
                 // Create all of this modules dependencies.  This includes both @Modules and injected
                 // dependencies
                 for (Class<? extends Module> dep : getIncludeList()) {
@@ -173,10 +166,6 @@ public class ModuleListBuilder {
     // Map of seen class to the provider.  Note that this map will not include any module
     // that is a simple 
     private Map<Class<? extends Module>, ModuleProvider> includes = Maps.newIdentityHashMap();
-    
-    // Map of modules classes and their replacement module
-    // TODO: Identify circular dependencies
-    private Map<Class<? extends Module>, Class<? extends Module>> replacements = Maps.newIdentityHashMap();
     
     // Set of module classes to exclude
     private Set<Class<? extends Module>> excludes = Sets.newIdentityHashSet();
@@ -277,19 +266,6 @@ public class ModuleListBuilder {
         return this;
     }
 
-    
-    public ModuleListBuilder replace(Class<? extends Module> m1, Class<? extends Module> m2) {
-        replacements.put(m1, m2);
-        include(m2);
-        return this;
-    }
-    
-    public ModuleListBuilder replace(Class<? extends Module> m1, Module m2) {
-        replacements.put(m1, m2.getClass());
-        include(m2);
-        return this;
-    }
-    
     private void registerModule(Module m) {
         if (m.getClass().isAnonymousClass()) {
             resolvedModules.add(m);

--- a/governator-core/src/main/java/com/netflix/governator/guice/transformer/OverrideAllDuplicateBindings.java
+++ b/governator-core/src/main/java/com/netflix/governator/guice/transformer/OverrideAllDuplicateBindings.java
@@ -1,0 +1,35 @@
+package com.netflix.governator.guice.transformer;
+
+import java.util.Collection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.netflix.governator.guice.ModuleTransformer;
+
+/**
+ * Treat any binding in list order as an override for previous bindings.
+ * 
+ * @author elandau
+ */
+public class OverrideAllDuplicateBindings implements ModuleTransformer {
+    
+    @Override
+    public Collection<Module> call(Collection<Module> modules) {
+        // Starting point
+        Module current = new AbstractModule() {
+            @Override
+            protected void configure() {
+            }
+        };
+
+        // Accumulate bindings while allowing for each to override all 
+        // previous bindings
+        for (Module module : modules) {
+            current = Modules.override(current).with(module);
+        }
+        return ImmutableList.of(current);
+    }
+
+}

--- a/governator-core/src/main/java/com/netflix/governator/guice/transformer/WarnAboutStaticInjections.java
+++ b/governator-core/src/main/java/com/netflix/governator/guice/transformer/WarnAboutStaticInjections.java
@@ -21,7 +21,7 @@ public class WarnAboutStaticInjections implements ModuleTransformer {
             element.acceptVisitor(new DefaultElementVisitor<Void>() {
                 @Override 
                 public Void visit(StaticInjectionRequest request) {
-                    LOG.info("You shouldn't be using static injection at: " + request.getSource());
+                    LOG.warn("You shouldn't be using static injection at: " + request.getSource());
                     return null;
                 }
             });

--- a/governator-core/src/test/java/com/netflix/governator/guice/TestGovernatorGuice.java
+++ b/governator-core/src/test/java/com/netflix/governator/guice/TestGovernatorGuice.java
@@ -16,6 +16,11 @@
 
 package com.netflix.governator.guice;
 
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -26,16 +31,23 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.netflix.governator.LifecycleInjectorBuilderProvider;
-import com.netflix.governator.guice.mocks.*;
+import com.netflix.governator.guice.mocks.ObjectWithGenericInterface;
+import com.netflix.governator.guice.mocks.SimpleContainer;
+import com.netflix.governator.guice.mocks.SimpleEagerSingleton;
+import com.netflix.governator.guice.mocks.SimpleGenericInterface;
+import com.netflix.governator.guice.mocks.SimpleInterface;
+import com.netflix.governator.guice.mocks.SimplePojo;
+import com.netflix.governator.guice.mocks.SimplePojoAlt;
+import com.netflix.governator.guice.mocks.SimpleProvider;
+import com.netflix.governator.guice.mocks.SimpleProviderAlt;
+import com.netflix.governator.guice.mocks.SimpleSingleton;
+import com.netflix.governator.guice.mocks.UnreferencedSingleton;
 import com.netflix.governator.guice.modules.ObjectA;
 import com.netflix.governator.guice.modules.ObjectB;
 import com.netflix.governator.lifecycle.FilteredLifecycleListener;
 import com.netflix.governator.lifecycle.LifecycleListener;
 import com.netflix.governator.lifecycle.LifecycleManager;
 import com.netflix.governator.lifecycle.LifecycleState;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import java.util.List;
 
 public class TestGovernatorGuice extends LifecycleInjectorBuilderProvider
 {

--- a/governator-core/src/test/java/com/netflix/governator/guice/TestModuleDependency.java
+++ b/governator-core/src/test/java/com/netflix/governator/guice/TestModuleDependency.java
@@ -111,47 +111,6 @@ public class TestModuleDependency {
     }
     
     @Test
-    public void shouldReplaceAnnotatedModule() throws Exception{
-        List<Module> modules = new ModuleListBuilder()
-            .include(AnnotatedModule.class)
-            .replace(AnnotatedModule.class, ReplacementAnnotatedModule.class)
-            .build(Guice.createInjector());
-        
-        assertEquals(modules, ReplacementAnnotatedModuleDependency.class, ReplacementAnnotatedModule.class);
-    }
-    
-    @Test
-    public void shouldReplaceAnnotatedModuleWithDependency() throws Exception{
-        List<Module> modules = new ModuleListBuilder()
-            .include(AnnotatedModule.class)
-            .replace(AnnotatedModuleDependency.class, ReplacementAnnotatedModuleDependency.class)
-            .build(Guice.createInjector());
-    
-        assertEquals(modules, ReplacementAnnotatedModuleDependency.class, AnnotatedModule.class);
-    }
-    
-    @Test
-    public void shouldReplaceInjectedModule() throws Exception{
-        List<Module> modules = new ModuleListBuilder()
-            .include(InjectedModule.class)
-            .replace(InjectedModule.class, ReplacementInjectedModule.class)
-            .build(Guice.createInjector());
-        
-        assertEquals(modules, ReplacementInjectedModuleDependency.class, ReplacementInjectedModule.class);
-        
-    }
-    
-    @Test
-    public void shouldReplaceInjectedModuleWithDependency() throws Exception{
-        List<Module> modules = new ModuleListBuilder()
-            .include(InjectedModule.class)
-            .replace(InjectedModuleDependency.class, ReplacementInjectedModuleDependency.class)
-            .build(Guice.createInjector());
-    
-        assertEquals(modules, ReplacementInjectedModuleDependency.class, InjectedModule.class);
-    }
-    
-    @Test
     public void shouldIncludeMultipleLevels() throws Exception{
         List<Module> modules = new ModuleListBuilder()
             .include(ParentAnnotatedModule.class)

--- a/governator-core/src/test/java/com/netflix/governator/guice/transformer/OverrideAllDuplicateBindingsTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/guice/transformer/OverrideAllDuplicateBindingsTest.java
@@ -1,0 +1,60 @@
+package com.netflix.governator.guice.transformer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.netflix.governator.guice.LifecycleInjector;
+
+public class OverrideAllDuplicateBindingsTest {
+    public static interface Foo {
+        
+    }
+    public static class Foo1 implements Foo {
+        
+    }
+    public static class Foo2 implements Foo {
+        
+    }
+    
+    public static class MyModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Foo.class).to(Foo1.class);
+        }
+    }
+    
+    public static class MyOverrideModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Foo.class).to(Foo2.class);
+        }
+    }
+    
+    @Test
+    public void testShouldFailOnDuplicate() {
+        try {
+            LifecycleInjector.builder()
+                .withModuleClasses(MyModule.class, MyOverrideModule.class)
+                .build()
+                .createInjector();
+            Assert.fail("Should have failed with duplicate binding");
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testShouldInstallDuplicate() {
+        Injector injector = LifecycleInjector.builder()
+            .withModuleTransformer(new OverrideAllDuplicateBindings())
+            .withModuleClasses(MyModule.class, MyOverrideModule.class)
+            .build()
+            .createInjector();
+        
+        Foo foo = injector.getInstance(Foo.class);
+        Assert.assertTrue(foo.getClass().equals(Foo2.class));
+    }
+}


### PR DESCRIPTION
Additional features in this pull request
1.  Get rid of module replacement, after some discussion this feature was deemed to complex and error prone.
2.  Add OverrideAllDuplicateBindings feature (enables via withModuleTransformer) that makes it so any module in the list of modules can override bindings in the previous module.  This feature is optional and does not provide any error/warning about overridden bindings.  That will be supported in a future version.
