### PR TITLE
Governation/guicification of apache commons cli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,15 @@ project(':governator-servlet') {
         compile     'javax.servlet:servlet-api:2.5'
         compile     'com.google.inject.extensions:guice-servlet:3.0'
         compile     "junit:junit-dep:4.+"
+    }
+}
+
+project(':governator-commons-cli') {
+    apply plugin: 'java'
+    dependencies {
+        compile     project(':governator')
+        compile     "commons-cli:commons-cli:1.2"
+        compile     "junit:junit-dep:4.+"
     
     }
 }

--- a/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/Cli.java
+++ b/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/Cli.java
@@ -1,0 +1,27 @@
+package com.netflix.governator.commons_cli;
+
+import com.google.inject.ProvisionException;
+import com.netflix.governator.annotations.binding.Main;
+import com.netflix.governator.guice.LifecycleInjector;
+import com.netflix.governator.guice.SimpleLifecycleInjectorBuilderSuite;
+
+public class Cli {
+    /**
+     * Utility method to start the CommonsCli using a main class and command line arguments
+     * 
+     * @param mainClass
+     * @param args
+     */
+    public static void start(Class<?> mainClass, final String[] args) {
+        try {
+            LifecycleInjector.bootstrap(mainClass, new SimpleLifecycleInjectorBuilderSuite() {
+                @Override
+                protected void configure() {
+                    bind(String[].class).annotatedWith(Main.class).toInstance(args);
+                }
+            });
+        } catch (Exception e) {
+            throw new ProvisionException("Error instantiating main class", e);
+        }
+    }
+}

--- a/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/modules/OptionsModule.java
+++ b/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/modules/OptionsModule.java
@@ -1,0 +1,290 @@
+package com.netflix.governator.commons_cli.modules;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
+import com.google.inject.ProvisionException;
+import com.google.inject.Singleton;
+import com.google.inject.binder.AnnotatedBindingBuilder;
+import com.google.inject.name.Names;
+import com.netflix.governator.annotations.binding.Main;
+import com.netflix.governator.commons_cli.providers.StringOptionProvider;
+
+/**
+ * Guicify Apache Commons CLI.  
+ * 
+ * Usages
+ * 
+ * <pre>
+ * {code
+ * 
+ * // When creating Guice
+ * 
+ * install(new OptionsModule() {
+ *    protected void configure() {
+ *       option("f")
+ *          .hasArg()
+ *          .withLongOpt("filename")
+ *          .annotatedWith(Filename.class);  // no need to call create()
+ *          
+ *    }
+ * })
+ * 
+ * // Inject into any class
+ * 
+ * @Singleton 
+ * public class MyService {
+ *    @Inject
+ *    public MyService(@Filename String filename) {
+ *    }
+ * }
+ * 
+ * // You can also inject CommandLine directly
+ * 
+ * @Singleton
+ * public class MyService {
+ *    @Inject
+ *    public MyService(CommandLine commandLine) {
+ *    }
+ * }
+ * 
+ * }
+ * </pre>
+ * 
+ * @author elandau
+ *
+ */
+public abstract class OptionsModule extends AbstractModule {
+    private static final Logger LOG = LoggerFactory.getLogger(OptionsModule.class);
+    
+    private List<OptionBuilder> builders = Lists.newArrayList();
+    private boolean parserIsBound = false;
+    
+    /**
+     * Non-static version of commons CLI OptionBuilder
+     * 
+     * @author elandau
+     */
+    protected class OptionBuilder {
+        private String longopt;
+        private String description;
+        private String argName;
+        private boolean required;
+        private int numberOfArgs = Option.UNINITIALIZED;
+        private Object type;
+        private boolean optionalArg;
+        private char valuesep;
+        private String shortopt;
+        private String defaultValue;
+        private Class<? extends Annotation> annot;
+
+        public OptionBuilder annotatedWith(Class<? extends Annotation> annot) {
+            this.annot = annot;
+            return this;
+        }
+        
+        public OptionBuilder withLongOpt(String longopt) {
+            this.longopt = longopt;
+            return this;
+        }
+
+        public OptionBuilder withShortOpt(char shortopt) {
+            this.shortopt = Character.toString(shortopt);
+            return this;
+        }
+
+        public OptionBuilder hasArg() {
+            this.numberOfArgs = 1;
+            return this;
+        }
+
+        public OptionBuilder hasArg(boolean hasArg) {
+            this.numberOfArgs = hasArg ? 1 : Option.UNINITIALIZED;
+            return this;
+        }
+
+        public OptionBuilder withArgName(String name) {
+            this.argName = name;
+            return this;
+        }
+
+        public OptionBuilder isRequired() {
+            this.required = true;
+            return this;
+        }
+
+        public OptionBuilder withValueSeparator(char sep) {
+            this.valuesep = sep;
+            return this;
+        }
+
+        public OptionBuilder withValueSeparator() {
+            this.valuesep = '=';
+            return this;
+        }
+
+        public OptionBuilder isRequired(boolean newRequired) {
+            this.required = newRequired;
+            return this;
+        }
+
+        public OptionBuilder hasArgs() {
+            this.numberOfArgs = Option.UNLIMITED_VALUES;
+            return this;
+        }
+
+        public OptionBuilder hasArgs(int num) {
+            this.numberOfArgs = num;
+            return this;
+        }
+
+        public OptionBuilder hasOptionalArg() {
+            this.numberOfArgs = 1;
+            this.optionalArg = true;
+            return this;
+        }
+
+        public OptionBuilder hasOptionalArgs() {
+            this.numberOfArgs = Option.UNLIMITED_VALUES;
+            this.optionalArg = true;
+            return this;
+        }
+
+        public OptionBuilder hasOptionalArgs(int numArgs) {
+            this.numberOfArgs = numArgs;
+            this.optionalArg = true;
+            return this;
+        }
+
+        public OptionBuilder withType(Object newType) {
+            this.type = newType;
+            return this;
+        }
+
+        public OptionBuilder withDescription(String newDescription) {
+            this.description = newDescription;
+            return this;
+        }
+        
+        public OptionBuilder withDefaultValue(String defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        Option create() throws IllegalArgumentException
+        {
+            Preconditions.checkNotNull(shortopt);
+            
+            Option option = null;
+            // create the option
+            option = new Option(shortopt, description);
+
+            // set the option properties
+            option.setLongOpt(longopt);
+            option.setRequired(required);
+            option.setOptionalArg(optionalArg);
+            option.setArgs(numberOfArgs);
+            option.setType(type);
+            option.setValueSeparator(valuesep);
+            option.setArgName(argName);
+
+            // return the Option instance
+            return option;
+        }
+    }
+    
+    /**
+     * On injection of CommandLine execute the BasicParser
+     * @author elandau
+     */
+    @Singleton
+    public static class CommandLineProvider implements Provider<CommandLine> {
+        private final Options options;
+        private final String[] arguments;
+        private final Parser parser;
+        
+        @Inject
+        public CommandLineProvider(Options options, @Main String[] arguments, Parser parser) {
+            this.options = options;
+            this.arguments = arguments;
+            this.parser = parser;
+        }
+        
+        @Override
+        public CommandLine get() {
+            try {
+                return parser.parse(options, arguments);
+            } catch (ParseException e) {
+                throw new ProvisionException("Error parsing command line arguments", e);
+            }
+        }
+    }
+    
+    @Override
+    protected final void configure() {
+        configureOptions();
+        
+        Options options = new Options();
+        for (OptionBuilder builder : builders) {
+            Option option = builder.create();
+            if (builder.annot != null) {
+                bind(String.class)
+                    .annotatedWith(builder.annot)
+                    .toProvider(new StringOptionProvider(option, builder.defaultValue))
+                    .asEagerSingleton();
+                
+                LOG.info("Binding option to annotation : " + builder.annot.getName());
+            }
+            else {
+                bind(String.class)
+                    .annotatedWith(Names.named(option.getOpt()))
+                    .toProvider(new StringOptionProvider(option, builder.defaultValue))
+                    .asEagerSingleton();
+                LOG.info("Binding option to String : " + option.getOpt());
+            }
+            options.addOption(option);
+        }
+        
+        bind(Options.class).toInstance(options);
+        bind(CommandLine.class).toProvider(CommandLineProvider.class);
+        
+        if (!parserIsBound) {
+            bindParser().to(BasicParser.class);
+        }
+    }
+    
+    protected abstract void configureOptions();
+
+    /**
+     * @param shortopt
+     * @return Return a builder through which a single option may be configured
+     */
+    protected OptionBuilder option(char shortopt) {
+        OptionBuilder builder = new OptionBuilder().withShortOpt(shortopt);
+        builders.add(builder);
+        return builder;
+    }
+    
+    /**
+     * Bind any parser.  BasicParser is used by default if no other parser is provided.
+     */
+    protected AnnotatedBindingBuilder<Parser> bindParser() {
+        parserIsBound = true;
+        return bind(Parser.class);
+    }
+}

--- a/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/providers/StringOptionProvider.java
+++ b/governator-commons-cli/src/main/java/com/netflix/governator/commons_cli/providers/StringOptionProvider.java
@@ -1,0 +1,49 @@
+package com.netflix.governator.commons_cli.providers;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import com.google.inject.Inject;
+import com.google.inject.spi.BindingTargetVisitor;
+import com.google.inject.spi.ProviderInstanceBinding;
+import com.google.inject.spi.ProviderWithExtensionVisitor;
+import com.google.inject.spi.Toolable;
+
+/**
+ * Custom provider that bridges an Option with an injectable String for the option value
+ * 
+ * @author elandau
+ *
+ */
+public class StringOptionProvider implements ProviderWithExtensionVisitor<String> {
+
+    private CommandLine commandLine;
+    private Option option;
+    private String defaultValue;
+
+    public StringOptionProvider(Option option, String defaultValue) {
+        this.option = option;
+    }
+    
+    @Override
+    public String get() {
+        return commandLine.getOptionValue(option.getOpt(), defaultValue);
+    }
+
+    /**
+     * This is needed for 'initialize(injector)' below to be called so the provider
+     * can get the injector after it is instantiated.
+     */
+    @Override
+    public <B, V> V acceptExtensionVisitor(
+            BindingTargetVisitor<B, V> visitor,
+            ProviderInstanceBinding<? extends B> binding) {
+        return visitor.visit(binding);
+    }
+
+    @Inject
+    @Toolable
+    void initialize(CommandLine commandLine) {
+        this.commandLine = commandLine;
+    }
+}

--- a/governator-commons-cli/src/test/java/com/netflix/governator/commons_cli/ExampleMain.java
+++ b/governator-commons-cli/src/test/java/com/netflix/governator/commons_cli/ExampleMain.java
@@ -1,0 +1,48 @@
+package com.netflix.governator.commons_cli;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import com.google.inject.AbstractModule;
+import com.netflix.governator.commons_cli.modules.OptionsModule;
+import com.netflix.governator.guice.annotations.GovernatorConfiguration;
+
+public class ExampleMain {
+    @GovernatorConfiguration
+    public static class MyBootstrap extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            bind(ExampleMain.class).asEagerSingleton();
+            
+            install(new OptionsModule() {
+                @Override
+                protected void configureOptions() {
+                    option('f').hasArgs();
+                }
+            });
+        }
+
+    }
+    
+    public static void main(final String args[]) {
+        Cli.start(MyBootstrap.class, args);
+    }
+
+    @Inject
+    public ExampleMain(@Named("f") String filename) {
+        System.out.println("filename=" + filename);
+    }
+    
+    @PostConstruct
+    public void initialize() {
+        System.out.println("Application starting");
+    }
+    
+    @PostConstruct
+    public void shutdown() {
+        System.out.println("Application stopping");
+    }
+
+}

--- a/governator-commons-cli/src/test/resources/log4j.properties
+++ b/governator-commons-cli/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2012 Netflix, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+log4j.rootLogger=ERROR, console
+
+log4j.logger.com.netflix.governator=DEBUG, console
+log4j.additivity.com.netflix.governator=false
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d %-5p %c %x %m [%t]%n

--- a/governator-core/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
+++ b/governator-core/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
@@ -165,7 +165,7 @@ public class LifecycleInjector
             try {
                 builder.withAdditionalModuleClasses(main);
             } catch (Exception e) {
-                throw new ProvisionException("Failed to create module for main class '" + main.getName() + "'");
+                throw new ProvisionException("Failed to create module for main class '" + main.getName() + "'", e);
             }
         }
         

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name='governator'
 include 'governator-core'
 include 'governator-servlet'
+include 'governator-commons-cli'
 include 'governator-test-junit'
 project(':governator-core').name = 'governator'


### PR DESCRIPTION
Integrate apache commons cli with governator to make it easier to specify command line options and make them injectable. 

Key features include
1.  Guice module to simplify specifying cli options
2.  Integraiton with governator's bootstrap mechanism.
3.  Customize command line parser via a binding
4.  Inject either apache commons's CommandLine or named bindings for each option

Example configuration,

``` java
@GovernatorConfiguration
public static class MyBootstrap extends AbstractModule { 
    @Override
    protected void configure() {
        bind(ExampleMain.class).asEagerSingleton();

        install(new OptionsModule() {
            @Override
            protected void configureOptions() {
                option('f').hasArgs();
            }
        });
    }
}
```

Example main,

``` java
public class ExampleMain {
     public static void main(final String args[]) {
         Cli.start(MyBootstrap.class, args);
     }

     @Inject
     public ExampleMain(@Named("f") String filename) {
        System.out.println("filename=" + filename);
     }

     @PostConstruct
     public void initialize() {
         System.out.println("Application starting");
     }

     @PreDestroy
     public void shutdown() {
         System.out.println("Application stopping");
    }
}
```
