### PR TITLE
Suite to load modules using the ServiceLoader

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/guice/serviceloader/ServiceLoaderSuite.java
+++ b/governator-core/src/main/java/com/netflix/governator/guice/serviceloader/ServiceLoaderSuite.java
@@ -1,0 +1,32 @@
+package com.netflix.governator.guice.serviceloader;
+
+import java.util.ServiceLoader;
+
+import com.google.inject.Module;
+import com.netflix.governator.guice.LifecycleInjectorBuilder;
+import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+
+/**
+ * LifecycleInjectorBuilderSuite that loads guice modules via the ServiceLoader.
+ * By default the ServiceLoaderSuite will load all Module derived classes.
+ * However, more specific module types (i.e. specific subclasses of Module)
+ * may be loaded as well.  
+ * 
+ * @author elandau
+ */
+public class ServiceLoaderSuite implements LifecycleInjectorBuilderSuite {
+    private final Class<? extends Module> type;
+    
+    public ServiceLoaderSuite() {
+        this(Module.class);
+    }
+    
+    public ServiceLoaderSuite(Class<? extends Module> type) {
+        this.type = type;
+    }
+    
+    @Override
+    public void configure(LifecycleInjectorBuilder builder) {
+        builder.withAdditionalModules(ServiceLoader.load(type));
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/guice/serviceloader/MyServiceLoadedModule.java
+++ b/governator-core/src/test/java/com/netflix/governator/guice/serviceloader/MyServiceLoadedModule.java
@@ -1,0 +1,11 @@
+package com.netflix.governator.guice.serviceloader;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+public class MyServiceLoadedModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(String.class).annotatedWith(Names.named("MyServiceLoadedModule")).toInstance("loaded");
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/guice/serviceloader/ServiceLoaderTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/guice/serviceloader/ServiceLoaderTest.java
@@ -1,7 +1,5 @@
 package com.netflix.governator.guice.serviceloader;
 
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -10,12 +8,14 @@ import junit.framework.Assert;
 
 import org.testng.annotations.Test;
 
-import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import com.google.inject.util.Types;
+import com.netflix.governator.guice.LifecycleInjector;
+import com.netflix.governator.guice.LifecycleInjectorBuilder;
 
 public class ServiceLoaderTest {
     public static class BoundServiceImpl implements TestService {
@@ -71,5 +71,13 @@ public class ServiceLoaderTest {
             Assert.assertTrue(service.isInjected());
             System.out.println("   " + service.getClass().getName());
         }
+    }
+    
+    @Test
+    public void testServiceLoadedModules() {
+        LifecycleInjectorBuilder builder = LifecycleInjector.builder();
+        new ServiceLoaderSuite().configure(builder);
+        Injector injector = builder.build().createInjector();
+        Assert.assertEquals("loaded",  injector.getInstance(Key.get(String.class, Names.named(MyServiceLoadedModule.class.getSimpleName()))));
     }
 }

--- a/governator-core/src/test/resources/META-INF/services/com.google.inject.Module
+++ b/governator-core/src/test/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.governator.guice.serviceloader.MyServiceLoadedModule


### PR DESCRIPTION
Usage

``` java
LifecycleInjectorBuilder builder = LifecycleInjector.builder();
new ServiceLoaderSuite().configure(builder);
Injector injector = builder.build().createInjector();
```

or using bootstrap

``` java
@GovernatorConfiguration(suites={ServiceLoaderSuite.class}) 
public class MyApplicationConfiguration extends AbstractModule {
    public void configure() {
    }
}
```
