### PR TITLE
LifecycleModule using ProvisionListener

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/LifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleListener.java
@@ -6,6 +6,11 @@ package com.netflix.governator;
  * code should use @PreDestroy, which is triggered via a LifecycleListener
  * enabled by installing {@link LifecycleModule}.
  * 
+ * When writing a LifecycleListener that is managed by Guice, make sure to 
+ * inject all dependencies lazily using {@link Provider} injection.  Otherwise,
+ * these dependencies will be instantiated too early thereby bypassing lifecycle 
+ * features in LifecycleModule.
+ * 
  * @author elandau
  */
 public interface LifecycleListener {

--- a/governator-core/src/main/java/com/netflix/governator/LoggingProvisionMetricsLifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/LoggingProvisionMetricsLifecycleListener.java
@@ -1,0 +1,47 @@
+package com.netflix.governator;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.governator.ProvisionMetrics.Element;
+import com.netflix.governator.ProvisionMetrics.Visitor;
+
+@Singleton
+public class LoggingProvisionMetricsLifecycleListener extends DefaultLifecycleListener {
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingProvisionMetricsLifecycleListener.class);
+    
+    private final ProvisionMetrics metrics;
+
+    @Inject
+    LoggingProvisionMetricsLifecycleListener(LifecycleManager manager, ProvisionMetrics metrics) {
+        this.metrics = metrics;
+        manager.addListener(this);
+    }
+    
+    @Override
+    public void onStarted() {
+        LOG.info("Injection provision report : \n" );
+        metrics.accept(new Visitor() {
+                int level = 1;
+                
+                @Override
+                public void visit(Element entry) {
+                    LOG.info(String.format("%" + (level * 3 - 2) + "s%s%s : %d ms (%d ms)", 
+                            "",
+                            entry.getKey().getTypeLiteral().toString(), 
+                            entry.getKey().getAnnotation() == null ? "" : " [" + entry.getKey().getAnnotation() + "]",
+                            entry.getTotalDuration(TimeUnit.MILLISECONDS),
+                            entry.getDuration(TimeUnit.MILLISECONDS)
+                            ));
+                    level++;
+                    entry.accept(this);
+                    level--;
+                }
+            });
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/NullProvisionMetrics.java
+++ b/governator-core/src/main/java/com/netflix/governator/NullProvisionMetrics.java
@@ -1,0 +1,23 @@
+package com.netflix.governator;
+
+import com.google.inject.Key;
+
+/**
+ * Default NoOp implementation of ProvisionMetrics.
+ * 
+ * @author elandau
+ *
+ */
+public class NullProvisionMetrics implements ProvisionMetrics {
+    @Override
+    public void push(Key<?> key) {
+    }
+
+    @Override
+    public void pop() {
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/ProvisionDebugModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/ProvisionDebugModule.java
@@ -1,0 +1,19 @@
+package com.netflix.governator;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+/**
+ * Install this module to log a Provision report after the Injector is created.
+ * 
+ * @author elandau
+ *
+ */
+public class ProvisionDebugModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), LifecycleListener.class).addBinding().to(LoggingProvisionMetricsLifecycleListener.class);
+        bind(ProvisionMetrics.class).to(SimpleProvisionMetrics.class);
+
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/ProvisionMetrics.java
+++ b/governator-core/src/main/java/com/netflix/governator/ProvisionMetrics.java
@@ -1,0 +1,63 @@
+package com.netflix.governator;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.inject.ImplementedBy;
+import com.google.inject.Key;
+
+/**
+ * Interface invoked by LifecycleModule's ProvisionListener to 
+ * gather metrics on objects as they are provisioned.  Through the
+ * provision listener it's possible to generate a dependency tree
+ * for the first initialization of all objects.  Note that no call
+ * will be made for singletons that are being injected but have 
+ * already been instantiated.
+ * 
+ * @author elandau
+ */
+@ImplementedBy(NullProvisionMetrics.class)
+public interface ProvisionMetrics {
+    
+    /**
+     * Node used to track metrics for an object that has been provisioned
+     * @author elandau
+     */
+    public static interface Element {
+        public Key<?> getKey();
+        
+        public long getDuration(TimeUnit units);
+        
+        public long getTotalDuration(TimeUnit units);
+        
+        public void accept(Visitor visitor);
+    }
+    
+    /**
+     * Visitor API for traversing nodes
+     * @author elandau
+     *
+     */
+    public static interface Visitor {
+        void visit(Element element);
+    }
+    
+    /**
+     * Notification that an object of type 'key' is about to be created.
+     * Note that there will likely be several nested calls to push() as
+     * dependencies are injected.
+     * @param key
+     */
+    public void push(Key<?> key);
+    
+    /**
+     * Pop and finalize initialization of the latest object to be provisioned.
+     * A matching pop will be called for each push(). 
+     */
+    public void pop();
+    
+    /**
+     * Traverse the elements using the visitor pattern.
+     * @param visitor
+     */
+    public void accept(Visitor visitor);
+}

--- a/governator-core/src/main/java/com/netflix/governator/SimpleProvisionMetrics.java
+++ b/governator-core/src/main/java/com/netflix/governator/SimpleProvisionMetrics.java
@@ -1,0 +1,107 @@
+package com.netflix.governator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Singleton;
+
+import com.google.inject.Key;
+
+@Singleton
+public class SimpleProvisionMetrics implements ProvisionMetrics {
+    private final ThreadLocal<Data> context = new ThreadLocal<Data>();
+    private final CopyOnWriteArraySet<Data> threads = new CopyOnWriteArraySet<>();
+    
+    public static class Data {
+        List<Entry> children = new ArrayList<>();
+        Stack<Entry> stack = new Stack<>();
+        
+        void accept(Visitor visit) {
+            for (Entry entry : children) {
+                visit.visit(entry);
+            }
+        }
+    }
+    
+    public static class Entry implements Element {
+        final Key<?>        key;
+        final List<Entry>   children  = new ArrayList<>();
+        final long          startTime = System.nanoTime();
+        long                endTime;
+        
+        Entry(Key<?> key) {
+            this.key = key;
+        }
+        
+        void add(Entry child) {
+            children.add(child);
+        }
+
+        void finish() {
+            endTime = System.nanoTime();
+        }
+        
+        @Override
+        public Key<?> getKey() {
+            return key;
+        }
+        
+        @Override
+        public void accept(Visitor visit) {
+            for (Entry entry : children) {
+                visit.visit(entry);
+            }
+        }
+
+        @Override
+        public long getDuration(TimeUnit units) {
+            long childDuration = 0;
+            for (Entry child : children) {
+                childDuration += child.getDuration(units);
+            }
+            return getTotalDuration(units) - childDuration;
+        }
+        
+        @Override
+        public long getTotalDuration(TimeUnit units) {
+            return units.convert(endTime - startTime, TimeUnit.NANOSECONDS);
+        }
+    }
+    
+    @Override
+    public void push(Key<?> type) {
+        Data data = context.get();
+        if (data == null) {
+            data = new Data();
+            context.set(data);
+            threads.add(data);
+        }
+        
+        Entry entry = new Entry(type);
+        
+        if (data.stack.isEmpty()) {
+            data.children.add(entry);
+        }
+        else {
+            data.stack.peek().add(entry);
+        }
+        data.stack.push(entry);
+    }
+
+    @Override
+    public void pop() {
+        Data data = context.get();
+        Entry entry = data.stack.pop();
+        entry.finish();
+    }
+    
+    @Override
+    public void accept(Visitor visitor) {
+        for (Data data : threads) {
+            data.accept(visitor);
+        };
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.Stage;
 import com.netflix.governator.annotations.Configuration;
 
@@ -116,4 +117,22 @@ public class LifecycleModuleTest {
         }
     }
 
+    @Test
+    public void testProvidesAnnotation() {
+        LifecycleInjector injector = Governator.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+            }
+            
+            @Provides
+            @Singleton
+            MySingleton createSingleton() {
+                System.out.println("***** Called");
+                return new MySingleton();
+            }
+        });
+        Assert.assertEquals(1, MySingleton.initCounter.get());
+        injector.shutdown();
+        Assert.assertEquals(1, MySingleton.shutdownCounter.get());
+    }
 }


### PR DESCRIPTION
Switch to using Guice4's ProvisionListener instead of InjectionListener.  Add support for tracking and logging provision metrics after the Injector is created.