### PR TITLE
Invoke pre destroy methods in the reverse order of post construct in LifecycleModule

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -82,7 +83,7 @@ public final class LifecycleModule extends SingletonModule {
     
     @Singleton
     static class LifecycleProvisionListener extends DefaultLifecycleListener implements ProvisionListener {
-        private final ConcurrentLinkedQueue<Runnable> shutdownActions = new ConcurrentLinkedQueue<Runnable>();
+        private final ConcurrentLinkedDeque<Runnable> shutdownActions = new ConcurrentLinkedDeque<Runnable>();
         private final ConcurrentMap<Class<?>, TypeLifecycleActions> cache = new ConcurrentHashMap<>();
         private Set<LifecycleFeature> features;
         private final AtomicBoolean isShutdown = new AtomicBoolean();
@@ -152,7 +153,7 @@ public final class LifecycleModule extends SingletonModule {
             // Add any PreDestroy methods to the shutdown list of actions
             if (!actions.preDestroyActions.isEmpty()) {
                 if (isShutdown.get() == false) {
-                    shutdownActions.add(new Runnable() {
+                    shutdownActions.addFirst(new Runnable() {
                         @Override
                         public void run() {
                             for (LifecycleAction m : actions.preDestroyActions) {


### PR DESCRIPTION
My application only depends on `governator-core` to get the life cycle features and I noticed that the invocation order of `@PreDestroy` methods is the same as the order of `@PostConstruct` but I was expecting to actually have the reverse order like when using the `LifeCycleManager` of the `governator-legacy` module:
https://github.com/Netflix/governator/blob/v1.8.1/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java#L528

Using the reverse order allows for a better graceful shutdown in my application without exceptions about a dependency being stopped/closed already. 

I added a new unit test to reproduce the behaviour and detect potential future regressions.