### PR TITLE
Fix class path scanning.  

### DIFF
--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/AnnotationFinder.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/AnnotationFinder.java
@@ -1,6 +1,8 @@
 package com.netflix.governator.lifecycle;
 
 import org.objectweb.asm.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -12,6 +14,8 @@ import java.util.Set;
 import static org.objectweb.asm.Type.*;
 
 public final class AnnotationFinder extends ClassVisitor {
+	private static Logger log = LoggerFactory.getLogger(AnnotationFinder.class);
+	
     private Set<Type> annotationTypes;
 
     private Set<Class<?>> annotatedClasses = Collections.emptySet();
@@ -162,6 +166,9 @@ public final class AnnotationFinder extends ClassVisitor {
                             annotatedMethods.add(selfClass().getDeclaredMethod(
                                     name, argClasses));
                     } 
+                    catch (NoClassDefFoundError e) {
+                    	log.info("Unable to scan constructor of '{}' NoClassDefFoundError looking for '{}'", selfClass().getName(), e.getMessage());
+                    }
                     catch (NoSuchMethodException e) {
                         throw new IllegalStateException(e);
                     }

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ClasspathScanner.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ClasspathScanner.java
@@ -109,9 +109,12 @@ public class ClasspathScanner {
             log.warn("No base packages specified - no classpath scanning will be done");
             return;
         }
+        log.info("Scanning packages : " + basePackages + " for annotations " + annotations);
+        
         try {
             for ( String basePackage : basePackages )  {
-                Enumeration<URL> resources = classLoader.getResources(basePackage.replace(".", "/"));
+            	String basePackageWithSlashes = basePackage.replace(".", "/");
+            	Enumeration<URL> resources = classLoader.getResources(basePackageWithSlashes);
                 while ( resources.hasMoreElements() ) {
                     URL url = resources.nextElement();
                     if ( isJarURL(url)) {
@@ -120,13 +123,12 @@ public class ClasspathScanner {
                             jarPath = jarPath.substring(0, jarPath.indexOf("!"));
                             url = new URL(jarPath);
                         }
-
                         File file = ClasspathUrlDecoder.toFile(url);
                         try (JarFile jar = new JarFile(file)) {
                             for ( Enumeration<JarEntry> list = jar.entries(); list.hasMoreElements(); ) {
                                 JarEntry entry = list.nextElement();
                                 try {
-                                    if ( entry.getName().endsWith(".class") && entry.getName().startsWith(basePackage) ) {
+                                    if ( entry.getName().endsWith(".class") && entry.getName().startsWith(basePackageWithSlashes)) {
                                         AnnotationFinder finder = new AnnotationFinder(classLoader, annotations.toArray(new Class[annotations.size()]));
                                         new ClassReader(jar.getInputStream(entry)).accept(finder, SKIP_CODE);
     

--- a/governator-legacy/src/test/java/com/netflix/governator/autobindmodule/good/TestAutoBindModuleInjection.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/autobindmodule/good/TestAutoBindModuleInjection.java
@@ -2,9 +2,14 @@ package com.netflix.governator.autobindmodule.good;
 
 import javax.inject.Inject;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.apple.laf.AquaButtonBorder.Named;
 import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import com.netflix.governator.annotations.AutoBindSingleton;
 import com.netflix.governator.guice.LifecycleInjector;
 
@@ -12,6 +17,7 @@ public class TestAutoBindModuleInjection {
     public static class FooModule extends AbstractModule {
         @Override
         protected void configure() {
+            bind(String.class).annotatedWith(Names.named("foo")).toInstance("found");
         }
     }
     
@@ -23,6 +29,7 @@ public class TestAutoBindModuleInjection {
         
         @Override
         protected void configure() {
+            bind(String.class).annotatedWith(Names.named("MyModule")).toInstance("found");
         }
     }
     
@@ -34,14 +41,18 @@ public class TestAutoBindModuleInjection {
         
         @Override
         protected void configure() {
+            bind(String.class).annotatedWith(Names.named("MyModule2")).toInstance("found");
         }
     }
     
     @Test
     public void shouldInjectModule() {
-        LifecycleInjector.builder().usingBasePackages(TestAutoBindModuleInjection.class.getPackage().getName())
+        Injector injector = LifecycleInjector.builder().usingBasePackages("com.netflix.governator.autobindmodule")
             .build()
             .createInjector();
         
+        Assert.assertEquals("found", injector.getInstance(Key.get(String.class, Names.named("MyModule"))));
+        Assert.assertEquals("found", injector.getInstance(Key.get(String.class, Names.named("MyModule2"))));
+        Assert.assertEquals("found", injector.getInstance(Key.get(String.class, Names.named("foo"))));
     }
 }


### PR DESCRIPTION
Log NoClassDefFoundError exceptions during class path scanning instead of failing completely.