### PR TITLE
Deprecate conditional module loading 

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/DefaultGovernatorConfiguration.java
+++ b/governator-core/src/main/java/com/netflix/governator/DefaultGovernatorConfiguration.java
@@ -195,7 +195,7 @@ public class DefaultGovernatorConfiguration implements GovernatorConfiguration {
     
     @Override
     public List<ModuleListProvider> getModuleListProviders() {
-        return Collections.unmodifiableList(moduleProviders);
+        return this.getAutoModuleListProviders();
     }
 
     @Override
@@ -225,6 +225,16 @@ public class DefaultGovernatorConfiguration implements GovernatorConfiguration {
 
     @Override
     public boolean isEnabled(GovernatorFeature feature) {
+        return isFeatureEnabled(feature);
+    }
+
+    @Override
+    public List<ModuleListProvider> getAutoModuleListProviders() {
+        return Collections.unmodifiableList(moduleProviders);
+    }
+
+    @Override
+    public boolean isFeatureEnabled(GovernatorFeature feature) {
         Boolean value = features.get(feature);
         return value == null
                 ? feature.isEnabledByDefault()

--- a/governator-core/src/main/java/com/netflix/governator/Governator.java
+++ b/governator-core/src/main/java/com/netflix/governator/Governator.java
@@ -151,8 +151,10 @@ public class Governator {
      *      +-------------------+
      *      
      *      
+     * @deprecated Functionality moved https://github.com/Netflix/karyon/tree/3.x
      * @return
      */
+    @Deprecated
     public static LifecycleInjector createInjector(final GovernatorConfiguration config) {
         Logger LOG = LoggerFactory.getLogger(Governator.class);
         LOG.info("Using profiles : " + config.getProfiles());

--- a/governator-core/src/main/java/com/netflix/governator/GovernatorConfiguration.java
+++ b/governator-core/src/main/java/com/netflix/governator/GovernatorConfiguration.java
@@ -34,7 +34,13 @@ public interface GovernatorConfiguration {
     /**
      * Return a list of ModuleListProviders through which modules may be auto-loaded.
      */
+    @Deprecated
     List<ModuleListProvider> getModuleListProviders();
+    
+    /**
+     * Return a list of ModuleListProviders through which modules may be auto-loaded.
+     */
+    List<ModuleListProvider> getAutoModuleListProviders();
     
     /**
      * Return a list of active profiles for the injector.  These profiles are used when
@@ -43,20 +49,27 @@ public interface GovernatorConfiguration {
     Set<String> getProfiles();
 
     /**
-     * Return the Guice injector stage.  The recommended default is Stage.DEVELOPMENT
-     * otherwise all singletons are eager, including lazy injection using Provider<T> 
-     */
-    Stage getStage();
-    
-    /**
      * Return the main property source to be used during the bootstrap phase 
      * @return
      */
     PropertySource getPropertySource();
     
     /**
+     * Return the Guice injector stage.  The recommended default is Stage.DEVELOPMENT
+     * otherwise all singletons are eager, including lazy injection using Provider<T> 
+     */
+    Stage getStage();
+    
+    /**
      * Determine if a core governator feature has been enabled.  See {@link GovernatorFeatures}
      * for available features.
      */
+    @Deprecated
     boolean isEnabled(GovernatorFeature feature);
+    
+    /**
+     * Determine if a core governator feature has been enabled.  See {@link GovernatorFeatures}
+     * for available features.
+     */
+    boolean isFeatureEnabled(GovernatorFeature feature);
 }

--- a/governator-core/src/main/java/com/netflix/governator/GovernatorFeature.java
+++ b/governator-core/src/main/java/com/netflix/governator/GovernatorFeature.java
@@ -6,7 +6,9 @@ package com.netflix.governator;
  * default value if not specified.  Features are set on GovernatorConfiguration.
  * 
  * @author elandau
+ * @deprecated Functionality moved https://github.com/Netflix/karyon/tree/3.x
  */
+@Deprecated
 public interface GovernatorFeature {
     public boolean isEnabledByDefault();
 }

--- a/governator-core/src/main/java/com/netflix/governator/GovernatorFeatures.java
+++ b/governator-core/src/main/java/com/netflix/governator/GovernatorFeatures.java
@@ -4,7 +4,9 @@ package com.netflix.governator;
  * Core governator features.  Features are configured/enabled on {@link GovernatorConfiguration}
  * 
  * @author elandau
+ * @deprecated Functionality moved https://github.com/Netflix/karyon/tree/3.x
  */
+@Deprecated
 public enum GovernatorFeatures implements GovernatorFeature {
     /**
      * When disabled, if the injector created using Governator.createInjector() fails the resulting

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/Conditional.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/Conditional.java
@@ -16,6 +16,10 @@ import com.netflix.governator.auto.Condition;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface Conditional { 
 
     /**

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnBinding.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnBinding.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnBindingCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnBindingCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnBinding {
     String[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnClass.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnClass.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnClassCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnClassCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnClass {
     String[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnEnvironment.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnEnvironment.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnEnvironmentCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnEnvironmentCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnEnvironment {
     String name();
     String value();

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnJUnit.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnJUnit.java
@@ -12,5 +12,9 @@ import com.netflix.governator.auto.conditions.OnJUnitCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnJUnitCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnJUnit {
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMacOS.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMacOS.java
@@ -12,5 +12,9 @@ import com.netflix.governator.auto.conditions.OnMacOSCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnMacOSCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnMacOS {
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingBinding.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingBinding.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnMissingBindingCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnMissingBindingCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnMissingBinding {
     String[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingClass.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingClass.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnMissingClassCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnMissingClassCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnMissingClass {
     String[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnMissingModule.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnMissingModuleCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnMissingModuleCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnMissingModule {
     String[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnModule.java
@@ -13,6 +13,10 @@ import com.netflix.governator.auto.conditions.OnModuleCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnModuleCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnModule {
     Class<? extends Module>[] value();
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnProfile.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnProfile.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnProfileCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnProfileCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnProfile {
     String[] value();
     

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnProperty.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnProperty.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnPropertyCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnPropertyCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnProperty {
     String name();
     String value();

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnSystem.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnSystem.java
@@ -12,6 +12,10 @@ import com.netflix.governator.auto.conditions.OnSystemCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnSystemCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnSystem {
     String name();
     String value();

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnTestNG.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/ConditionalOnTestNG.java
@@ -12,5 +12,9 @@ import com.netflix.governator.auto.conditions.OnTestNGCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Conditional(OnTestNGCondition.class)
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface ConditionalOnTestNG {
 }

--- a/governator-core/src/main/java/com/netflix/governator/auto/annotations/OverrideModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/annotations/OverrideModule.java
@@ -7,5 +7,9 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public @interface OverrideModule {
 } 

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnBindingCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnBindingCondition.java
@@ -9,6 +9,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnBinding;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnBindingCondition implements Condition<ConditionalOnBinding> {
     private final AutoContext context;
 

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnClassCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnClassCondition.java
@@ -5,6 +5,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnClass;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnClassCondition implements Condition<ConditionalOnClass> {
     @Override
     public boolean check(ConditionalOnClass condition) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnEnvironmentCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnEnvironmentCondition.java
@@ -5,6 +5,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnProperty;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnEnvironmentCondition implements Condition<ConditionalOnProperty> {
     @Override
     public boolean check(ConditionalOnProperty condition) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnJUnitCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnJUnitCondition.java
@@ -5,6 +5,10 @@ import javax.inject.Singleton;
 import com.netflix.governator.auto.Condition;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnJUnitCondition implements Condition<OnJUnitCondition>{
     @Override
     public boolean check(OnJUnitCondition param) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMacOSCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMacOSCondition.java
@@ -6,6 +6,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnMacOS;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnMacOSCondition implements Condition<ConditionalOnMacOS>{
     @Override
     public boolean check(ConditionalOnMacOS param) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingBindingCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingBindingCondition.java
@@ -9,6 +9,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnMissingBinding;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnMissingBindingCondition implements Condition<ConditionalOnMissingBinding> {
     private final AutoContext context;
 

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingClassCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingClassCondition.java
@@ -3,6 +3,10 @@ package com.netflix.governator.auto.conditions;
 import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnMissingClass;
 
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnMissingClassCondition implements Condition<ConditionalOnMissingClass> {
     @Override
     public boolean check(ConditionalOnMissingClass condition) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingModuleCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnMissingModuleCondition.java
@@ -8,6 +8,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnMissingModule;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnMissingModuleCondition implements Condition<ConditionalOnMissingModule>{
     private final AutoContext context;
     

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnModuleCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnModuleCondition.java
@@ -8,6 +8,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnModule;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnModuleCondition implements Condition<ConditionalOnModule> {
     private final AutoContext context;
     

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnProfileCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnProfileCondition.java
@@ -8,6 +8,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnProfile;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnProfileCondition implements Condition<ConditionalOnProfile> {
 
     private AutoContext context;

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnPropertyCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnPropertyCondition.java
@@ -8,6 +8,10 @@ import com.netflix.governator.auto.PropertySource;
 import com.netflix.governator.auto.annotations.ConditionalOnProperty;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnPropertyCondition implements Condition<ConditionalOnProperty> {
 
     private PropertySource config;

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnSystemCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnSystemCondition.java
@@ -5,6 +5,10 @@ import com.netflix.governator.auto.Condition;
 import com.netflix.governator.auto.annotations.ConditionalOnSystem;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnSystemCondition implements Condition<ConditionalOnSystem> {
     @Override
     public boolean check(ConditionalOnSystem condition) {

--- a/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnTestNGCondition.java
+++ b/governator-core/src/main/java/com/netflix/governator/auto/conditions/OnTestNGCondition.java
@@ -5,6 +5,10 @@ import javax.inject.Singleton;
 import com.netflix.governator.auto.Condition;
 
 @Singleton
+@Deprecated
+/**
+ * @deprecated Moved to Karyon3
+ */
 public class OnTestNGCondition implements Condition<OnTestNGCondition>{
     @Override
     public boolean check(OnTestNGCondition param) {

--- a/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
+++ b/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Injector;
+import com.google.inject.ProvisionException;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.netflix.governator.LifecycleShutdownSignal;
 
@@ -88,10 +89,10 @@ public abstract class GovernatorServletContextListener extends GuiceServletConte
         }
         catch (Exception e) {
             LOG.error("Failed to created injector", e);
-            return null;
+            throw new ProvisionException("Failed to create injector", e);
         }
     }
     
-    protected abstract Injector createInjector();
+    protected abstract Injector createInjector() throws Exception;
 
 }


### PR DESCRIPTION
This functionality has been moved to Karyon3, https://github.com/Netflix/karyon/tree/3.x as it was mostly developed specifically for karyon3 and it doesn't make sense to keep the projects separate.  At some point Karyon3 will likely assimilate all governator functionality. 