### PR TITLE
Deprecate AutoBindSingleton and log INFO messages where it's used.

### DIFF
--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * AutoBindProvider to automatically/programmatically bind fields and constructor/method
  * arguments
  * 
- * @deprecated 10/10/2015 Deprecated in favor of standard Guice modules. 
+ * @deprecated 2015-10-10 Deprecated in favor of standard Guice modules. 
  *             See https://github.com/Netflix/governator/wiki/Auto-Binding
  */
 @Documented

--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
@@ -26,11 +26,14 @@ import java.lang.annotation.Target;
  * Annotation binding that combines with Governator's classpath scanning and a bound
  * AutoBindProvider to automatically/programmatically bind fields and constructor/method
  * arguments
+ * 
+ * @deprecated Deprecated in favor of standard Guice modules
  */
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER})
 @Qualifier
+@Deprecated
 public @interface AutoBind
 {
     /**

--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBind.java
@@ -27,7 +27,8 @@ import java.lang.annotation.Target;
  * AutoBindProvider to automatically/programmatically bind fields and constructor/method
  * arguments
  * 
- * @deprecated Deprecated in favor of standard Guice modules
+ * @deprecated 10/10/2015 Deprecated in favor of standard Guice modules. 
+ *             See https://github.com/Netflix/governator/wiki/Auto-Binding
  */
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)

--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
@@ -22,7 +22,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a class as a singleton. Governator will auto-bind it as an eager singleton
- * @deprecated  AutoBindSingleton is deprecated in favor of bindings in a Guice Module.
+ * @deprecated  10/10/2015 AutoBindSingleton is deprecated in favor of bindings in a Guice Module.
+ *              See https://github.com/Netflix/governator/wiki/Auto-Binding
  */
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)

--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a class as a singleton. Governator will auto-bind it as an eager singleton
- * @deprecated  10/10/2015 AutoBindSingleton is deprecated in favor of bindings in a Guice Module.
+ * @deprecated  2015-10-10 AutoBindSingleton is deprecated in favor of bindings in a Guice Module.
  *              See https://github.com/Netflix/governator/wiki/Auto-Binding
  */
 @Documented

--- a/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
+++ b/governator-annotations/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
@@ -22,10 +22,12 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a class as a singleton. Governator will auto-bind it as an eager singleton
+ * @deprecated  AutoBindSingleton is deprecated in favor of bindings in a Guice Module.
  */
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target(java.lang.annotation.ElementType.TYPE)
+@Deprecated
 public @interface AutoBindSingleton
 {
     /**

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
@@ -187,7 +187,7 @@ class InternalAutoBindModule extends AbstractModule
     private void bindAutoBindSingleton(AutoBindSingleton annotation, Class<?> clazz)
     {
         LOG.info("Installing @AutoBindSingleton '{}'", clazz.getName());
-        LOG.info("***** @AutoBindSingleton for '{}' is deprecated as of 10/10/2015.\nPlease use a Guice module with bind({}.class).asEagerSingleton() instead.\nSee https://github.com/Netflix/governator/wiki/Auto-Binding", 
+        LOG.info("***** @AutoBindSingleton for '{}' is deprecated as of 2015-10-10.\nPlease use a Guice module with bind({}.class).asEagerSingleton() instead.\nSee https://github.com/Netflix/governator/wiki/Auto-Binding", 
                 clazz.getName(), clazz.getSimpleName() );
         
         Singleton singletonAnnotation = clazz.getAnnotation(Singleton.class);

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
@@ -25,6 +25,8 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.inject.Singleton;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -184,8 +186,14 @@ class InternalAutoBindModule extends AbstractModule
 
     private void bindAutoBindSingleton(AutoBindSingleton annotation, Class<?> clazz)
     {
-        LOG.info("Installing @AutoBindSingleton " + clazz.getName());
+        LOG.info("Installing @AutoBindSingleton '{}'", clazz.getName());
+        LOG.info("***** @AutoBindSingleton for '{}' is deprecated soon.\nPlease use a Guice module with bind({}.class).asEagerSingleton(); instead", 
+                clazz.getName(), clazz.getSimpleName() );
         
+        Singleton singletonAnnotation = clazz.getAnnotation(Singleton.class);
+        if (singletonAnnotation == null) {
+            LOG.info("***** {} should also be annotation with @Singleton to ensure singleton behavior", clazz.getName());
+        }
         Class<?> annotationBaseClass = getAnnotationBaseClass(annotation);
         if ( annotationBaseClass != AutoBindSingleton.class )    // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null
         {

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
@@ -187,12 +187,12 @@ class InternalAutoBindModule extends AbstractModule
     private void bindAutoBindSingleton(AutoBindSingleton annotation, Class<?> clazz)
     {
         LOG.info("Installing @AutoBindSingleton '{}'", clazz.getName());
-        LOG.info("***** @AutoBindSingleton for '{}' is deprecated soon.\nPlease use a Guice module with bind({}.class).asEagerSingleton(); instead", 
+        LOG.info("***** @AutoBindSingleton for '{}' is deprecated as of 10/10/2015.\nPlease use a Guice module with bind({}.class).asEagerSingleton() instead.\nSee https://github.com/Netflix/governator/wiki/Auto-Binding", 
                 clazz.getName(), clazz.getSimpleName() );
         
         Singleton singletonAnnotation = clazz.getAnnotation(Singleton.class);
         if (singletonAnnotation == null) {
-            LOG.info("***** {} should also be annotation with @Singleton to ensure singleton behavior", clazz.getName());
+            LOG.info("***** {} should also be annotated with @Singleton to ensure singleton behavior", clazz.getName());
         }
         Class<?> annotationBaseClass = getAnnotationBaseClass(annotation);
         if ( annotationBaseClass != AutoBindSingleton.class )    // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
@@ -63,6 +63,7 @@ public class InternalAutoBindModuleBootstrapModule implements BootstrapModule {
                         "@AutoBindSingleton(multiple=true) value cannot be set for Modules");
 
                 LOG.info("Found @AutoBindSingleton annotated module : {} ", clazz.getName());
+                LOG.info("***** @AutoBindSingleton for module {} is deprecated.  Modules should be added directly to the injector or via install({}.class)", clazz.getName(), clazz.getSimpleName());
                 binder.include((Class<? extends Module>) clazz);
             } 
         }

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
@@ -63,7 +63,7 @@ public class InternalAutoBindModuleBootstrapModule implements BootstrapModule {
                         "@AutoBindSingleton(multiple=true) value cannot be set for Modules");
 
                 LOG.info("Found @AutoBindSingleton annotated module : {} ", clazz.getName());
-                LOG.info("***** @AutoBindSingleton for module {} is deprecated as of 10/10/2015.  Modules should be added directly to the injector or via install({}.class). See https://github.com/Netflix/governator/wiki/Auto-Binding", clazz.getName(), clazz.getSimpleName());
+                LOG.info("***** @AutoBindSingleton use for module {} is deprecated as of 2015-10-10.  Modules should be added directly to the injector or via install({}.class). See https://github.com/Netflix/governator/wiki/Auto-Binding", clazz.getName(), clazz.getSimpleName());
                 binder.include((Class<? extends Module>) clazz);
             } 
         }

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
@@ -63,7 +63,7 @@ public class InternalAutoBindModuleBootstrapModule implements BootstrapModule {
                         "@AutoBindSingleton(multiple=true) value cannot be set for Modules");
 
                 LOG.info("Found @AutoBindSingleton annotated module : {} ", clazz.getName());
-                LOG.info("***** @AutoBindSingleton for module {} is deprecated.  Modules should be added directly to the injector or via install({}.class)", clazz.getName(), clazz.getSimpleName());
+                LOG.info("***** @AutoBindSingleton for module {} is deprecated as of 10/10/2015.  Modules should be added directly to the injector or via install({}.class). See https://github.com/Netflix/governator/wiki/Auto-Binding", clazz.getName(), clazz.getSimpleName());
                 binder.include((Class<? extends Module>) clazz);
             } 
         }


### PR DESCRIPTION
@AutoBindSingleton is a very misused feature of Governator and has caused numerous issues with applications having random classes annotated with @AutoBindSingleton being picked up and instantiated.  Furthermore, since @AutoBindSingleton is not a proper Guice Scope its use is misleading since @AutoBindSingleton classes injected without being picked up by the class path scanner aren't actually singletons.  

Moving forward it is recommended that any eager singleton should be specified in a Guice module and bound .asEagerSingleton().  

@AutoBindSingleton for modules is also being deprecated.  Instead, modules should be installed directly at injector creation or transitively via binder.install().