### PR TITLE
WIP: ConditionalBinder

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/PropertiesPropertySource.java
+++ b/governator-core/src/main/java/com/netflix/governator/PropertiesPropertySource.java
@@ -4,19 +4,33 @@ import java.util.Properties;
 
 import javax.inject.Singleton;
 
+import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.netflix.governator.spi.PropertySource;
 
-public class PropertiesPropertySource extends AbstractPropertySource {
+public final class PropertiesPropertySource extends AbstractPropertySource implements Module {
     private Properties props;
 
     public PropertiesPropertySource(Properties props) {
         this.props = props;
     }
 
+    public PropertiesPropertySource() {
+        this(new Properties());
+    }
+
     public static PropertiesPropertySource from(Properties props) {
         return new PropertiesPropertySource(props);
+    }
+    
+    public PropertiesPropertySource setProperty(String key, String value) {
+        props.setProperty(key, value);
+        return this;
+    }
+    
+    public boolean hasProperty(String key, String value) {
+        return props.containsKey(key);
     }
     
     public static Module toModule(final Properties props) {
@@ -38,4 +52,28 @@ public class PropertiesPropertySource extends AbstractPropertySource {
     public String get(String key, String defaultValue) {
         return props.getProperty(key, defaultValue);
     }
+
+    @Override
+    public void configure(Binder binder) {
+        binder.bind(PropertySource.class).toInstance(this);
+    }
+    
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+
+        throw new RuntimeException("Only one PropertiesModule may be installed");
+    }
+
+
 }

--- a/governator-core/src/main/java/com/netflix/governator/conditional/Conditional.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/Conditional.java
@@ -1,0 +1,15 @@
+package com.netflix.governator.conditional;
+
+
+/**
+ * Contract for any conditional that may be applied to a conditional binding
+ * bound via {@link ConditionalBinder}.
+ */
+public interface Conditional<T extends Conditional<T>> {
+    /**
+     * @return Class that can process this conditional.  This class
+     * is instantiated by Guice and is therefore injectable.  The class should be 
+     * annotated as a {@literal @}Singleton 
+     */
+    Class<? extends Matcher<T>> getMatcherClass();
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBinder.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBinder.java
@@ -1,0 +1,406 @@
+package com.netflix.governator.conditional;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.inject.Binder;
+import com.google.inject.Binding;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.internal.Errors;
+import com.google.inject.spi.BindingTargetVisitor;
+import com.google.inject.spi.Dependency;
+import com.google.inject.spi.Message;
+import com.google.inject.spi.ProviderInstanceBinding;
+import com.google.inject.spi.ProviderWithExtensionVisitor;
+import com.google.inject.spi.Toolable;
+
+/**
+ * An API to bind multiple conditional candidates separately, only to evaluate and 
+ * resolve to one candidate when the type is actually injected.  
+ * ConditionalBinder is intended for use in a Module
+ * 
+ * <pre><code>
+ * public class SnacksModule extends AbstractModule {
+ *   protected void configure() {
+ *     ConditionalBinder&lt;Snack&gt; conditionalbinder
+ *         = ConditionalBinder.newConditionalBinder(binder(), Snack.class);
+ *     multibinder.when(new ConditionalOnProperty("type", "twix")).toInstance(new Twix());
+ *     multibinder.when(new ConditionalOnProperty("type", "snickers")).toProvider(SnickersProvider.class);
+ *     multibinder.when(new ConditionalOnProperty("type", "skittles")).to(Skittles.class);
+ *     multibinder.whenNone().to(Carrots.class);
+ *   }
+ * }</code></pre>
+ *
+ * <p>With this binding when injecting {@code <Snack>} all conditionals will be evaluated and only
+ * the single matched binding will be injected
+ * <pre><code>
+ * class SnackMachine {
+ *   {@literal @}Inject
+ *   public SnackMachine(Snack snacks) { ... }
+ * }</code></pre>
+ *
+ * <p>Contributing conditional bindings from different modules is supported. For
+ * example, it is okay for both {@code CandyModule} and {@code ChipsModule}
+ * to create their own {@code ConditionalBinder<Snack>}, and to each contribute
+ * conditional bindings to the set of candidate snacks.  When a Snack is injected, it will 
+ * use the one conditional bindings that matched.
+ *
+ * Exactly one conditional binding may be matched.  An exception will be thrown 
+ * when Snack is injected and no or multiple bindings' conditions are matched.
+ * 
+ * <p>Conditionals are evaluated at injection time. If an element is bound to a
+ * provider, that provider's get method will be called each time Snack is
+ * injected (unless the binding is in Singleton scope, in which case Guice will cache
+ * the first call to get).
+ * 
+ * Conditionals may only be used in Stage.DEVELOPMENT since running in Stage.PRODUCTION will
+ * result in every Singleton conditional candidate being instantiated eagerly.  Any attempt
+ * to binding in Stage.PRODUCTION will result in a CreationException
+ * 
+ * TODO: Strip all conditional bindings of their scope so they cannot be eager singletons.
+ *       Alternatively, force lazy singleton behavior
+ * TODO: Discuss whether the conditional binder key should be singleton by default  
+ */
+public abstract class ConditionalBinder<T> {
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type}.
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(Binder binder, TypeLiteral<T> type) {
+        return newRealConditionalBinder(binder, Key.get(type));
+    }
+
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type}.
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(Binder binder, Class<T> type) {
+        return newRealConditionalBinder(binder, Key.get(type));
+    }
+
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type} with 
+     * the qualifier {@code annotation}
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(
+        Binder binder, TypeLiteral<T> type, Annotation annotation) {
+        return newRealConditionalBinder(binder, Key.get(type, annotation));
+    }
+
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type} with 
+     * the qualifier {@code annotation}
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(
+        Binder binder, Class<T> type, Annotation annotation) {
+        return newRealConditionalBinder(binder, Key.get(type, annotation));
+    }
+
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type} with 
+     * the qualifier {@code annotation}
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(Binder binder, TypeLiteral<T> type,
+        Class<? extends Annotation> annotationType) {
+        return newRealConditionalBinder(binder, Key.get(type, annotationType));
+    }
+
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code key} where
+     * key may or may not have a qualifier.
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(Binder binder, Key<T> key) {
+        return newRealConditionalBinder(binder, key);
+    }    
+  
+    /**
+     * Returns a new ConditionalBinder that tracks all candidate instances of {@code type} with 
+     * the qualifier {@code annotation}
+     */
+    public static <T> ConditionalBinder<T> newConditionalBinder(Binder binder, Class<T> type,
+            Class<? extends Annotation> annotationType) {
+        return newRealConditionalBinder(binder, Key.get(type, annotationType));
+    }
+
+    static <T> ConditionalBinder<T> newRealConditionalBinder(Binder binder, Key<T> key) {
+        if (binder.currentStage().equals(Stage.PRODUCTION)) {
+            throw new RuntimeException("ConditionalBinder may not be used in Stage.PRODUCTION.  Use Stage.DEVELOPMENT.");
+        }
+
+        binder = binder.skipSources(RealConditionalBinder.class, ConditionalBinder.class);
+        RealConditionalBinder<T> result = new RealConditionalBinder<T>(binder, key);
+        binder.install(result);
+        return result;
+    }
+    
+    /**
+     * Returns a binding builder used to add a new conditional candidate for the key. 
+     * Each bound element must have a distinct value. Only the matching candidate will
+     * be instantiated and its provider cached when the key is first injected.
+     *
+     * <p>It is an error to call this method without also calling one of the
+     * {@code to} methods on the returned binding builder.
+     *
+     * <p>Scoping elements independently supported per binding. Use the {@code in} method
+     * to specify a binding scope.
+     */
+    public abstract LinkedBindingBuilder<T> whenMatch(Conditional obj);
+
+    /**
+     * Returns a binding builder used to specify the candidate for the key when no other
+     * conditional bindings have been met.  There can be only one default candidate.  Only the
+     * matching candidate will be instantiated and its provider cached when the key is 
+     * first injected.
+     *
+     * <p>It is an error to call this method without also calling one of the
+     * {@code to} methods on the returned binding builder.
+     *
+     * <p>Scoping elements independently supported per binding. Use the {@code in} method
+     * to specify a binding scope.
+     */
+    public abstract LinkedBindingBuilder<T> whenNoMatch();
+    
+    static final class RealConditionalBinder<T> extends ConditionalBinder<T>
+        implements Module, ProviderWithExtensionVisitor<T>, ConditionalBinding<T> {
+        
+        private final TypeLiteral<T> elementType;
+        private final String keyName;
+        private final Key<T> primaryKey;
+        private ImmutableList<Binding<T>> candidateBindings;
+        private Set<Dependency<?>> dependencies;
+
+        private Provider<T> matchedProvider;
+        private Binder binder;
+        
+        public RealConditionalBinder(
+                Binder binder,
+                Key<T> key) {
+            this.binder = checkNotNull(binder, "binder");
+            this.primaryKey = checkNotNull(key, "key");
+            this.elementType = checkNotNull(key.getTypeLiteral(), "elementType");
+            this.keyName = checkNotNull(ConditionalElementImpl.nameOf(key), "keyName");
+        }
+        
+        @Override
+        public void configure(Binder binder) {
+            checkConfiguration(!isInitialized(), "ConditionalBinder was already initialized");
+            binder.bind(primaryKey).toProvider(this);
+        }
+        
+        Key<T> getKeyForNewItem(Conditional obj) {
+            checkConfiguration(!isInitialized(), "ConditionalBinder was already initialized");
+            return Key.get(elementType, new ConditionalElementImpl(keyName, obj));
+        }
+
+        @Override 
+        public LinkedBindingBuilder<T> whenMatch(Conditional obj) {
+            return binder.bind(getKeyForNewItem(obj));
+        }
+
+        @Override
+        public LinkedBindingBuilder<T> whenNoMatch() {
+            return binder.bind(getKeyForNewItem(null));
+        }
+
+        /**
+         * Invoked by Guice at Injector-creation time to prepare providers for each
+         * element in this set. 
+         */
+        @Toolable 
+        @Inject 
+        void initialize(Injector injector) {
+            List<Binding<T>> candidateBindings = Lists.newArrayList();
+            Binding<T> matchedBinding = null;
+            Binding<T> defaultBinding = null;
+            
+            Set<Indexer.IndexedBinding> index = Sets.newHashSet();
+            Indexer indexer = new Indexer(injector);
+            List<Dependency<?>> dependencies = Lists.newArrayList();
+            
+            for (Binding<?> entry : injector.findBindingsByType(elementType)) {
+                if (keyMatches(entry.getKey())) {
+                    @SuppressWarnings("unchecked") // protected by findBindingsByType()
+                    Binding<T> binding = (Binding<T>) entry;
+                    if (index.add(binding.acceptTargetVisitor(indexer))) {
+                        candidateBindings.add(binding);
+                        
+                        Conditional condition = ((ConditionalElementImpl) entry.getKey().getAnnotation()).getCondition();
+                        if (condition == null) {
+                            if (defaultBinding == null) {
+                                defaultBinding = binding;
+                            }
+                            else {
+                                throw newDuplicateBindingException(primaryKey, defaultBinding, binding);
+                            }
+                        }
+                        else {
+                            @SuppressWarnings("unchecked")
+                            Class matcherType = condition.getMatcherClass();
+                            Matcher matcher = (Matcher)injector.getInstance(matcherType);
+                            if (matcher.match(condition)) {
+                                if (matchedBinding == null) {
+                                    matchedBinding = binding;
+                                }
+                                else {
+                                    throw newDuplicateBindingException(primaryKey, matchedBinding, binding);
+                                }
+                            }
+                        }
+                        dependencies.add(Dependency.get(binding.getKey()));
+                    }
+                }
+            }
+            
+            if (matchedBinding == null) {
+                matchedBinding = defaultBinding;
+            }
+            
+            if (matchedBinding == null) {
+                throw newNoMatchingBindingException(primaryKey, candidateBindings);
+            }
+            
+            dependencies.add(Dependency.get(matchedBinding.getKey()));
+            this.matchedProvider = matchedBinding.getProvider();
+            
+            this.candidateBindings = ImmutableList.copyOf(candidateBindings);
+            this.binder = null;
+        }
+
+        private boolean keyMatches(Key<?> key) {
+            return key.getTypeLiteral().equals(elementType)
+                && key.getAnnotation() instanceof ConditionalElement
+                && ((ConditionalElement) key.getAnnotation()).keyName().equals(keyName);
+        }
+
+        @Override
+        public T get() {
+            checkConfiguration(isInitialized(), "ConditionalBinder is not initialized");
+            return matchedProvider.get();
+        }
+        
+        @Override
+        public Key<T> getKey() {
+            return primaryKey;
+        }
+        
+        @Override
+        public List<Binding<?>> getCandidateElements() {
+            if (isInitialized()) {
+                return (List<Binding<?>>) (List<?>) candidateBindings; // safe because bindings is immutable.
+            } 
+            else {
+                throw new UnsupportedOperationException("getElements() not supported for module bindings");
+            }
+        }
+        
+        @Override
+        public <B, V> V acceptExtensionVisitor(
+                BindingTargetVisitor<B, V> visitor,
+                ProviderInstanceBinding<? extends B> binding) {
+            if (visitor instanceof ConditionalBindingsTargetVisitor) {
+                return ((ConditionalBindingsTargetVisitor<T, V>) visitor).visit(this);
+            } 
+            else {
+                return visitor.visit(binding);
+            }
+        }
+        
+        private boolean isInitialized() {
+            return binder == null;
+        }
+
+        @Override
+        public boolean containsElement(com.google.inject.spi.Element element) {
+            if (element instanceof Binding) {
+                Binding<?> binding = (Binding<?>) element;
+                return keyMatches(binding.getKey())
+                  || binding.getKey().equals(primaryKey);
+            } 
+            else {
+                return false;
+            }
+        }
+        
+        @Override
+        public int hashCode() {
+            return primaryKey.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            RealConditionalBinder other = (RealConditionalBinder) obj;
+            return primaryKey.equals(other.primaryKey);
+        }
+    }
+
+    static void checkConfiguration(boolean condition, String format, Object... args) {
+        if (condition) {
+            return;
+        }
+
+        throw new ConfigurationException(ImmutableSet.of(new Message(Errors.format(format, args))));
+    }
+    
+    private static <T> ConfigurationException newDuplicateBindingException(
+            Key<T> key,
+            Binding<T> existingBindings,
+            Binding<T> duplicateBinding) {
+        // When the value strings don't match, include them both as they may be useful for debugging
+        return new ConfigurationException(ImmutableSet.of(new Message(Errors.format(
+                "%s injection failed due to multiple matching conditionals:"
+                    + "\n    \"%s\"\n        bound at %s"
+                    + "\n    \"%s\"\n        bound at %s",
+                key,
+                duplicateBinding.getKey(),
+                duplicateBinding.getSource(),
+                existingBindings.getKey(),
+                existingBindings.getSource()))));
+    }
+
+    private static <T> ConfigurationException newNoMatchingBindingException(
+            Key<T> key,
+            List<Binding<T>> candidateBindings) {
+        
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("%s injection failed due to no matching conditional", key));
+        
+        if (!candidateBindings.isEmpty()) {
+            for (Binding<T> binding : candidateBindings) {
+                builder.append(String.format("\n    \"%s\"\n        bound at %s", 
+                        binding.getKey(),
+                        binding.getSource()));
+            }
+        }
+        else {
+            builder.append("\n    No to() bindings were specified ");
+        }
+        return new ConfigurationException(ImmutableSet.of(new Message(Errors.format(builder.toString()))));
+    }
+
+    static <T> T checkNotNull(T reference, String name) {
+        if (reference != null) {
+            return reference;
+        }
+
+        NullPointerException npe = new NullPointerException(name);
+        throw new ConfigurationException(ImmutableSet.of(new Message(npe
+                .toString(), npe)));
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBinding.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBinding.java
@@ -1,0 +1,25 @@
+package com.netflix.governator.conditional;
+
+import java.util.List;
+
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.spi.Element;
+
+/**
+ * Binding object passed to a ConditionalBindingTargetVisitor when visiting
+ * Guice's bindings
+ */
+public interface ConditionalBinding<T> {
+    /**
+     * @return  Key for the main type for which there are conditional bindings
+     */
+    Key<T> getKey();
+
+    /**
+     * @return  All candidate elements of which one should match
+     */
+    List<Binding<?>> getCandidateElements();
+
+    boolean containsElement(Element element);
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBindingsTargetVisitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalBindingsTargetVisitor.java
@@ -1,0 +1,7 @@
+package com.netflix.governator.conditional;
+
+import com.google.inject.spi.BindingTargetVisitor;
+
+public interface ConditionalBindingsTargetVisitor<T, V> extends BindingTargetVisitor<T, V> {
+    V visit(ConditionalBinding<? extends T> conditionalBinding);
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalElement.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalElement.java
@@ -1,0 +1,19 @@
+package com.netflix.governator.conditional;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import com.google.inject.BindingAnnotation;
+
+/**
+ * Unique qualifier associated with conditional bindings.  The unique qualifier
+ * is used to ensure that the bound element isn't bound to a real key that user
+ * code would inject.
+ */
+@Retention(RUNTIME) 
+@BindingAnnotation
+@interface ConditionalElement {
+    String keyName();
+    int uniqueId();
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalElementImpl.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalElementImpl.java
@@ -1,0 +1,84 @@
+package com.netflix.governator.conditional;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.google.inject.Key;
+import com.google.inject.internal.Annotations;
+
+class ConditionalElementImpl implements ConditionalElement {
+    private static final AtomicInteger nextUniqueId = new AtomicInteger(1);
+
+    private final int uniqueId;
+    private final String keyName;
+    private final Conditional condition;
+
+    ConditionalElementImpl(String keyName, Conditional condition) {
+        this(keyName, condition, nextUniqueId.incrementAndGet());
+    }
+
+    ConditionalElementImpl(String keyName, Conditional condition, int uniqueId) {
+        this.uniqueId = uniqueId;
+        this.keyName = keyName;
+        this.condition = condition;
+    }
+
+    @Override
+    public String keyName() {
+        return keyName;
+    }
+
+    @Override
+    public int uniqueId() {
+        return uniqueId;
+    }
+
+    public Conditional getCondition() {
+        return condition;
+    }
+
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return ConditionalElement.class;
+    }
+
+    @Override
+    public String toString() {
+        return "@" + ConditionalElement.class.getName() + "(keyName=" + keyName
+                + ",uniqueId=" + uniqueId + ",condition=" + condition + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ConditionalElement
+                && ((ConditionalElement) o).keyName().equals(keyName())
+                && ((ConditionalElement) o).uniqueId() == uniqueId();
+    }
+
+    @Override
+    public int hashCode() {
+        return ((127 * "keyName".hashCode()) ^ keyName.hashCode())
+             + ((127 * "uniqueId".hashCode()) ^ uniqueId);
+    }
+
+    /**
+     * Returns the name the binding should use. This is based on the annotation.
+     * If the annotation has an instance and is not a marker annotation, we ask
+     * the annotation for its toString. If it was a marker annotation or just an
+     * annotation type, we use the annotation's name. Otherwise, the name is the
+     * empty string.
+     */
+    static String nameOf(Key<?> key) {
+        Annotation annotation = key.getAnnotation();
+        Class<? extends Annotation> annotationType = key.getAnnotationType();
+        if (annotation != null && !Annotations.isMarker(annotationType)) {
+            return key.getAnnotation().toString();
+        } 
+        else if (key.getAnnotationType() != null) {
+            return "@" + key.getAnnotationType().getName();
+        } 
+        else {
+            return "";
+        }
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalOnProfile.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalOnProfile.java
@@ -1,0 +1,41 @@
+package com.netflix.governator.conditional;
+
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import com.google.inject.Inject;
+import com.netflix.governator.annotations.binding.Profiles;
+
+final public class ConditionalOnProfile implements Conditional<ConditionalOnProfile> {
+    private String profile;
+
+    public ConditionalOnProfile(String profile) {
+        this.profile = profile;
+    }
+
+    @Override
+    public Class<? extends Matcher<ConditionalOnProfile>> getMatcherClass() {
+        return ConditionalOnProfileMatcher.class;
+    }
+    
+    @Override
+    public String toString() {
+        return "ConditionalOnProfile[" + profile + "]";
+    }
+
+    @Singleton
+    final public static class ConditionalOnProfileMatcher implements Matcher<ConditionalOnProfile> {
+        @Inject(optional=true)
+        @Profiles
+        Set<String> profiles;
+        
+        @Override
+        public boolean match(ConditionalOnProfile condition) {
+            if (profiles == null) {
+                return false;
+            }
+            return profiles.contains(condition.profile);
+        }
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalOnProperty.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/ConditionalOnProperty.java
@@ -1,0 +1,43 @@
+package com.netflix.governator.conditional;
+
+import javax.inject.Singleton;
+
+import com.google.inject.Inject;
+import com.netflix.governator.spi.PropertySource;
+
+/**
+ * Conditional that evaluates to true if the a property is set to a specific value
+ */
+public class ConditionalOnProperty implements Conditional<ConditionalOnProperty> {
+    private String value;
+    private String key;
+
+    public ConditionalOnProperty(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public Class<? extends Matcher<ConditionalOnProperty>> getMatcherClass() {
+        return ConditionalOnPropertyMatcher.class;
+    }
+
+    @Override
+    public String toString() {
+        return "ConditionalOnProperty[" + key + "=" + value + "]";
+    }
+    
+    @Singleton
+    public static class ConditionalOnPropertyMatcher implements Matcher<ConditionalOnProperty> {
+        @Inject(optional=true)
+        PropertySource properties;
+        
+        @Override
+        public boolean match(ConditionalOnProperty condition) {
+            if (properties == null) {
+                return false;
+            }
+            return condition.value.equals(properties.get(condition.key, ""));
+        }
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/Indexer.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/Indexer.java
@@ -1,0 +1,185 @@
+package com.netflix.governator.conditional;
+
+/**
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.annotation.Annotation;
+
+import com.google.common.base.Objects;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Scope;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.BindingScopingVisitor;
+import com.google.inject.spi.ConstructorBinding;
+import com.google.inject.spi.ConvertedConstantBinding;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.ExposedBinding;
+import com.google.inject.spi.InstanceBinding;
+import com.google.inject.spi.LinkedKeyBinding;
+import com.google.inject.spi.ProviderBinding;
+import com.google.inject.spi.ProviderInstanceBinding;
+import com.google.inject.spi.ProviderKeyBinding;
+import com.google.inject.spi.UntargettedBinding;
+
+/**
+ * Visits bindings to return a {@code IndexedBinding} that can be used to
+ * emulate the binding deduplication that Guice internally performs.
+ */
+class Indexer extends
+        DefaultBindingTargetVisitor<Object, Indexer.IndexedBinding> implements
+        BindingScopingVisitor<Object> {
+    enum BindingType {
+        INSTANCE, PROVIDER_INSTANCE, PROVIDER_KEY, LINKED_KEY, UNTARGETTED, CONSTRUCTOR, CONSTANT, EXPOSED, PROVIDED_BY,
+    }
+
+    static class IndexedBinding {
+        final String annotationName;
+        final TypeLiteral<?> typeLiteral;
+        final Object scope;
+        final BindingType type;
+        final Object extraEquality;
+
+        IndexedBinding(Binding<?> binding, BindingType type, Object scope,
+                Object extraEquality) {
+            this.scope = scope;
+            this.type = type;
+            this.extraEquality = extraEquality;
+            this.typeLiteral = binding.getKey().getTypeLiteral();
+            ConditionalElement annotation = (ConditionalElement) binding.getKey().getAnnotation();
+            this.annotationName = annotation.keyName();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof IndexedBinding)) {
+                return false;
+            }
+            IndexedBinding o = (IndexedBinding) obj;
+            return type == o.type && Objects.equal(scope, o.scope)
+                    && typeLiteral.equals(o.typeLiteral)
+                    && annotationName.equals(o.annotationName)
+                    && Objects.equal(extraEquality, o.extraEquality);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(type, scope, typeLiteral, annotationName,
+                    extraEquality);
+        }
+    }
+
+    final Injector injector;
+
+    Indexer(Injector injector) {
+        this.injector = injector;
+    }
+
+    boolean isIndexable(Binding<?> binding) {
+        return binding.getKey().getAnnotation() instanceof ConditionalElement;
+    }
+
+    private Object scope(Binding<?> binding) {
+        return binding.acceptScopingVisitor(this);
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            ConstructorBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.CONSTRUCTOR,
+                scope(binding), binding.getConstructor());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            ConvertedConstantBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.CONSTANT,
+                scope(binding), binding.getValue());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(ExposedBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.EXPOSED,
+                scope(binding), binding);
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            InstanceBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.INSTANCE,
+                scope(binding), binding.getInstance());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            LinkedKeyBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.LINKED_KEY,
+                scope(binding), binding.getLinkedKey());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            ProviderBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.PROVIDED_BY,
+                scope(binding), injector.getBinding(binding.getProvidedKey()));
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            ProviderInstanceBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding,
+                BindingType.PROVIDER_INSTANCE, scope(binding),
+                binding.getUserSuppliedProvider());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            ProviderKeyBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.PROVIDER_KEY,
+                scope(binding), binding.getProviderKey());
+    }
+
+    @Override
+    public Indexer.IndexedBinding visit(
+            UntargettedBinding<? extends Object> binding) {
+        return new Indexer.IndexedBinding(binding, BindingType.UNTARGETTED,
+                scope(binding), null);
+    }
+
+    private static final Object EAGER_SINGLETON = new Object();
+
+    @Override
+    public Object visitEagerSingleton() {
+        return EAGER_SINGLETON;
+    }
+
+    @Override
+    public Object visitNoScoping() {
+        return Scopes.NO_SCOPE;
+    }
+
+    @Override
+    public Object visitScope(Scope scope) {
+        return scope;
+    }
+
+    @Override
+    public Object visitScopeAnnotation(
+            Class<? extends Annotation> scopeAnnotation) {
+        return scopeAnnotation;
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/conditional/Matcher.java
+++ b/governator-core/src/main/java/com/netflix/governator/conditional/Matcher.java
@@ -1,0 +1,14 @@
+package com.netflix.governator.conditional;
+
+/**
+ * Matcher for a specific conditional.  Matchers are created by Guice and
+ * are therefore injectable.
+ * @param <T>
+ */
+public interface Matcher<T extends Conditional> {
+    /**
+     * @param condition
+     * @return Evaluate the conditional and return true if matched
+     */
+    boolean match(T condition);
+}

--- a/governator-core/src/test/java/com/netflix/governator/conditional/ConditionalBinderTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/conditional/ConditionalBinderTest.java
@@ -1,0 +1,346 @@
+package com.netflix.governator.conditional;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Stage;
+import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
+import com.netflix.governator.PropertiesPropertySource;
+
+public class ConditionalBinderTest {
+    @Rule
+    public TestName name = new TestName();
+    
+    public static interface Foo {
+        public String getName();
+    }
+    
+    public static class FooImpl implements Foo {
+        private final String name;
+
+        public FooImpl(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+    
+    @Singleton
+    static class SingletonFoo implements Foo {
+        static int injectedCount = 0;
+        
+        @Inject
+        SingletonFoo() {
+            injectedCount++;
+        }
+
+        @Override
+        public String getName() {
+            return "singleton";
+        }
+    }
+    
+    static class NonSingletonFoo implements Foo {
+        static int injectedCount = 0;
+        
+        @Inject
+        NonSingletonFoo() {
+            injectedCount++;
+        }
+
+        @Override
+        public String getName() {
+            return "nonsingleton";
+        }
+    }
+    
+    @Before
+    public void before() {
+        SingletonFoo.injectedCount = 0;
+        NonSingletonFoo.injectedCount = 0;
+    }
+    
+    public static class ModuleGroup1 extends AbstractModule {
+        @Override
+        protected void configure() {
+            ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+            
+            binder.whenMatch(new ConditionalOnProperty("group1", "a"))
+                .toInstance(new FooImpl("group1_a"));
+            binder.whenMatch(new ConditionalOnProperty("group1", "b"))
+                .toInstance(new FooImpl("group1_b"));
+            binder.whenNoMatch()
+                .toInstance(new FooImpl("group1_default"));
+        }
+    }
+    
+    public static class ModuleGroup2 extends AbstractModule {
+        @Override
+        protected void configure() {
+            ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class, Names.named("group2"));
+            
+            binder.whenMatch(new ConditionalOnProperty("group2", "a"))
+                .toInstance(new FooImpl("group2_a"));
+            binder.whenMatch(new ConditionalOnProperty("group2", "b"))
+                .toInstance(new FooImpl("group2_b"));
+        }
+    }
+    
+    public static class ModuleNoConditional extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(Key.get(Foo.class)).toInstance(new FooImpl("unconditional"));
+        }
+    }
+    
+    @Test
+    public void bindToMatchedOfMultipleConditionals() {
+        Injector injector = Guice.createInjector(
+            new PropertiesPropertySource()
+                .setProperty("group1", "a"),
+            new ModuleGroup1());
+        
+        Foo foo1 = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo1.getName(), "group1_a");
+    }
+    
+    @Test
+    public void simpleWithDefault() {
+        Injector injector = Guice.createInjector(
+            new PropertiesPropertySource(),
+            new ModuleGroup1());
+        
+        Foo foo1 = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo1.getName(), "group1_default");
+    }
+    
+    @Test
+    public void differentiateBetweenMultipleQualifiers() {
+        Injector injector = Guice.createInjector(
+            new PropertiesPropertySource()
+                .setProperty("group1", "a")
+                .setProperty("group2", "b"),
+            new ModuleGroup1(), 
+            new ModuleGroup2());
+        
+        Foo foo1 = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo1.getName(), "group1_a");
+        
+        Foo foo2 = injector.getInstance(Key.get(Foo.class, Names.named("group2")));
+        Assert.assertEquals(foo2.getName(), "group2_b");
+    }
+    
+    @Test
+    public void overrideConditionalWithNonConditional() {
+        Injector injector = Guice.createInjector(Modules.override(
+                new PropertiesPropertySource()
+                    .setProperty("group1", "a"),
+                new ModuleGroup1()
+                )
+            .with(
+                new ModuleNoConditional()));
+        
+        Foo foo = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo.getName(), "unconditional");
+    }
+    
+    @Test
+    public void bindToSingleConditionalWithNoDefault() {
+        Injector injector = Guice.createInjector(
+            new PropertiesPropertySource()
+                .setProperty("foo", "value"),
+            new AbstractModule() {
+                @Override
+                protected void configure() {
+                    ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                    
+                    binder.whenMatch(new ConditionalOnProperty("foo", "value"))
+                        .toInstance(new FooImpl("value"));
+                }
+            });
+        
+        Foo foo = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo.getName(), "value");
+    }
+
+    @Test
+    public void bindToJustDefault() {
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                
+                binder.whenNoMatch()
+                    .toInstance(new FooImpl("default"));
+            }
+        });
+        
+        Foo foo = injector.getInstance(Key.get(Foo.class));
+        Assert.assertEquals(foo.getName(), "default");
+    }
+
+    @Test
+    public void confirmSingletonConditionalBehavior() {
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                binder.whenNoMatch().to(SingletonFoo.class);
+                
+                bind(SingletonFoo.class);
+            }            
+        });
+        
+        Assert.assertEquals(0, SingletonFoo.injectedCount);
+        Foo foo1 = injector.getInstance(Foo.class);
+        Assert.assertEquals(1, SingletonFoo.injectedCount);
+        Foo foo2 = injector.getInstance(Foo.class);
+        Assert.assertEquals(1, SingletonFoo.injectedCount);
+    }
+    
+    @Test
+    public void confirmSingletonNotEagerlyCreated() {
+        Assert.assertEquals(0, SingletonFoo.injectedCount);
+        Assert.assertEquals(0, NonSingletonFoo.injectedCount);
+        
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                binder.whenMatch(new ConditionalOnProperty("foo", "1")).to(SingletonFoo.class);
+                binder.whenNoMatch().to(NonSingletonFoo.class);
+            }
+        });
+        
+        Assert.assertEquals(0, SingletonFoo.injectedCount);
+        Assert.assertEquals(0, NonSingletonFoo.injectedCount);
+        Foo foo1 = injector.getInstance(Foo.class);
+        Foo foo2 = injector.getInstance(Foo.class);
+        Assert.assertEquals(0, SingletonFoo.injectedCount);
+        Assert.assertEquals(2, NonSingletonFoo.injectedCount);
+        Assert.assertEquals(foo1.getName(), "nonsingleton");
+    }
+    
+    @Test(expected=CreationException.class)
+    public void failWithNoMatchedConditionals(){
+        try {
+            Guice.createInjector(new ModuleGroup1(), new ModuleGroup2());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+   
+    @Test(expected=CreationException.class)
+    public void failWithNoBindTo(){
+        try {
+            Guice.createInjector(
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                    }
+                });
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+    
+    @Test(expected=CreationException.class)
+    public void failWithDuplicateMatchedConditionals(){
+        try {
+            Guice.createInjector(
+                new PropertiesPropertySource()
+                    .setProperty("group1", "a"),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                        
+                        binder.whenMatch(new ConditionalOnProperty("group1", "a"))
+                            .toInstance(new FooImpl("group1_a"));
+                        binder.whenMatch(new ConditionalOnProperty("group1", "a"))
+                            .toInstance(new FooImpl("group1_b"));
+                    }
+                });
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+   
+    @Test(expected=CreationException.class)
+    public void failOnMultipleDefaults() {
+        try {
+            Guice.createInjector(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                    
+                    binder.whenNoMatch()
+                        .toInstance(new FooImpl("default1"));
+                    binder.whenNoMatch()
+                        .toInstance(new FooImpl("default2"));
+                }
+            });
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test(expected=CreationException.class)
+    public void conflictingConditionalAndNonConditional() {
+        try {
+            Guice.createInjector(
+                new PropertiesPropertySource()
+                    .setProperty("group1", "a"),
+                new ModuleGroup1(),
+                new ModuleNoConditional());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+    
+    @Test(expected=CreationException.class)
+    public void productionStageNotSupported() {
+        try {
+            Guice.createInjector(Stage.PRODUCTION, new AbstractModule() {
+                @Override
+                protected void configure() {
+                    ConditionalBinder<Foo> binder = ConditionalBinder.newConditionalBinder(binder(), Foo.class);
+                    
+                    binder.whenNoMatch().to(SingletonFoo.class);
+                    binder.whenMatch(new ConditionalOnProperty("foo", "1")).to(NonSingletonFoo.class);
+                }
+            });
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+
+    }
+}


### PR DESCRIPTION
The ConditionalBinder enables specifying multiple candidates for a binding with each having a condition that can be based on configuration or other state.  ConditionalBinder follows an implementation very similar to Multibinder in that all bindings are created with custom annotations and are resolved at injector creation time. 

For example,
```java
public class SnacksModule extends AbstractModule {
    protected void configure() {
      ConditionalBinder<Snack> conditionalbinder
          = ConditionalBinder.newConditionalBinder(binder(), Snack.class);
      multibinder.when(new ConditionalOnProperty("type", "twix")).toInstance(new Twix());
      multibinder.when(new ConditionalOnProperty("type", "snickers")).toProvider(SnickersProvider.class);
      multibinder.when(new ConditionalOnProperty("type", "skittles")).to(Skittles.class);
      multibinder.whenNone().to(Carrots.class);
     }
}
 ```

The following situations are not valid and result in a CreationException error at injector creation (not injection) time.  The exception will contain detailed information on the candidate bindings and where in code they were bound
#.  Multiple matching candidates
#.  No matched candidates
#.  Multiple default bindings specified
#.  Using conditional binding in Stage.PRODUCTION

Several approaches were considered for implementing this feature, including a Module annotation based approach.  The benefits of this approach are,
#.  Follows Guice conventions (such as Multibinder and MapBinder)
#.  Does not require Module post processing (which would complicate usage)
#.  Makes conditional processing injectable

Drawbacks to this approach are,
#.  Does not work in Stage.PRODUCTION (results in unmatched conditionals being instantiated).  Allowing this to run in production stage is possible but would add complexity that may not be necessary since we run only in the lazy Stage.DEVELOPMENT.  We can revisit this if running in Stage.PRODUCTION becomes are requirement.  
#.  Unmatched conditionals result in unused bindings