### PR TITLE
removed redundant and outdated servlet-api dependency

### DIFF
--- a/governator-jetty/build.gradle
+++ b/governator-jetty/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'java'
 
 dependencies {
     compile project(':governator-core')
-    compile 'javax.servlet:servlet-api:2.5'
     compile 'com.google.inject.extensions:guice-servlet:4.0'
     compile 'com.sun.jersey:jersey-server:1.19'
     compile 'org.eclipse.jetty:jetty-servlet:9.2.12.v20150709'


### PR DESCRIPTION
javax.servlet-api is already coming from jetty-server. This dependency was outdated and causing multiple  versions of the servlet-api to be present on the classpath.