### PR TITLE
Fix Servlet Context Listener shutdown bug.

### DIFF
--- a/governator-servlet/build.gradle
+++ b/governator-servlet/build.gradle
@@ -5,4 +5,7 @@ dependencies {
     compile     'com.google.inject.extensions:guice-servlet:4.0'
 
     provided    'javax.servlet:javax.servlet-api:3.0.1'
+
+    testCompile "org.mockito:mockito-all:1.9.5"
+    testCompile 'junit:junit:4.10'
 }

--- a/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
+++ b/governator-servlet/src/main/java/com/netflix/governator/guice/servlet/GovernatorServletContextListener.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package com.netflix.governator.guice.servlet;
 
 import javax.servlet.ServletContextEvent;
@@ -64,8 +80,6 @@ public class StartServer extends GovernatorServletContextListener
 public abstract class GovernatorServletContextListener extends GuiceServletContextListener {
     protected static final Logger LOG = LoggerFactory.getLogger(GovernatorServletContextListener.class);
 
-    static final String INJECTOR_NAME = Injector.class.getName();
-
     private Injector injector;
     
     public void contextInitialized(ServletContextEvent servletContextEvent) {
@@ -82,15 +96,21 @@ public abstract class GovernatorServletContextListener extends GuiceServletConte
     /**
      * Override this method to create (or otherwise obtain a reference to) your
      * injector.
+     * NOTE: If everything is set up right, then this method should only be called once during
+     * application startup.
      */
     protected final Injector getInjector() {
+        if (injector != null) {
+            throw new IllegalStateException("Injector already created.");
+        }
         try {
-            return createInjector();
+            injector = createInjector();
         }
         catch (Exception e) {
             LOG.error("Failed to created injector", e);
             throw new ProvisionException("Failed to create injector", e);
         }
+        return injector;
     }
     
     protected abstract Injector createInjector() throws Exception;

--- a/governator-servlet/src/test/java/com/netflix/governator/guice/servlet/GovernatorServletContextListenerTest.java
+++ b/governator-servlet/src/test/java/com/netflix/governator/guice/servlet/GovernatorServletContextListenerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.netflix.governator.guice.servlet;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.netflix.governator.LifecycleShutdownSignal;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+/**
+ * @author Nikos Michalakis <nikos@netflix.com>
+ */
+public class GovernatorServletContextListenerTest {
+
+    private GovernatorServletContextListener listener;
+    private LifecycleShutdownSignal mockLifecycleSignal;
+
+    @Before
+    public void setUp() {
+        mockLifecycleSignal = Mockito.mock(LifecycleShutdownSignal.class);
+        listener = new GovernatorServletContextListener() {
+            @Override
+            protected Injector createInjector() throws Exception {
+                return Guice.createInjector(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(LifecycleShutdownSignal.class).toInstance(mockLifecycleSignal);
+                    }
+                });
+            }
+        };
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGetInjectorIsCreatedOnlyOnce() {
+        Injector injector = listener.getInjector();
+        Assert.assertNotNull(injector);
+        listener.getInjector();
+    }
+
+    @Test
+    public void testContextDestroyedAfterInjectorIsCreated() {
+        // The app starts and gets an injector.
+        listener.getInjector();
+        // Now we make sure it's signalled when we shutdown.
+        ServletContextEvent servletContextEvent = Mockito.mock(ServletContextEvent.class);
+        ServletContext mockServletContext = Mockito.mock(ServletContext.class);
+        Mockito.when(servletContextEvent.getServletContext()).thenReturn(mockServletContext);
+        listener.contextDestroyed(servletContextEvent);
+        Mockito.verify(mockLifecycleSignal).signal();
+    }
+}


### PR DESCRIPTION
The GovernatorServletContextListener never set its internal
injector instance so at shutdown it never sent a signal to the lifecycle
listener to call all the @PreDestroy methods (among things) when the
application shuts down and before the JVM does.