### PR TITLE
ordering for lifecycle listeners, fix equality in SafeLifecycleListener

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
 
     dependencies {
         testCompile 'org.testng:testng:6.1.1'
-        testCompile 'org.slf4j:slf4j-log4j12:1.7.2'
+        testCompile "org.slf4j:slf4j-log4j12:${slf4j_version}"
     }
 
     eclipse {

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -13,5 +13,11 @@ dependencies {
     testCompile "org.mockito:mockito-all:1.9.5"
     testCompile "junit:junit:4.10"
     testCompile "com.google.code.findbugs:jsr305:3.0.0"
+    
+    test {
+        useJUnit()
+    }
+
+
 
 }

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 dependencies {
     compile     project(':governator-api')
     compile     "javax.inject:javax.inject:1"
-    compile     "org.slf4j:slf4j-api:1.6.3"
+    compile     "org.slf4j:slf4j-api:${slf4j_version}"
     compile     "com.google.inject:guice:${guice_version}"
     compile     "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile     "com.google.inject.extensions:guice-grapher:${guice_version}"    // should be provided - only if you want graphing

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleInjectorCreator.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleInjectorCreator.java
@@ -116,7 +116,7 @@ public class LifecycleInjectorCreator implements InjectorCreator<LifecycleInject
             return lifecycleInjector;
         }
         catch (Exception e) {
-            LOG.error(String.format("Failed to create injector - %s@%d", e.getClass().getSimpleName(), System.identityHashCode(e)), e);
+            LOG.error("Failed to create injector - {}@{}", e.getClass().getSimpleName(), System.identityHashCode(e), e);
             onFailedInjectorCreate(e);
             try {
               manager.notifyStartFailed(e);

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleInjectorCreator.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleInjectorCreator.java
@@ -116,10 +116,10 @@ public class LifecycleInjectorCreator implements InjectorCreator<LifecycleInject
             return lifecycleInjector;
         }
         catch (Exception e) {
-            LOG.error("Failed to create injector", e);
+            LOG.error(String.format("Failed to create injector - %s@%d", e.getClass().getSimpleName(), System.identityHashCode(e)), e);
             onFailedInjectorCreate(e);
             try {
-                manager.notifyStartFailed(e);
+              manager.notifyStartFailed(e);
             }
             catch (Exception e2) {
                 LOG.error("Failed to notify injector creation failure", e2 );

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleListenerModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleListenerModule.java
@@ -34,7 +34,7 @@ public final class LifecycleListenerModule extends AbstractModule {
     
     @Singleton
     @SuppressLifecycleUninitialized
-    static class LifecycleListenerProvisionListener extends AbstractLifecycleListener implements ProvisionListener {
+    static class LifecycleListenerProvisionListener implements ProvisionListener {
         private LifecycleManager manager;
         private List<LifecycleListener> pendingLifecycleListeners = new ArrayList<>();
         

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
@@ -1,6 +1,8 @@
 package com.netflix.governator;
 
+import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,7 +25,7 @@ public final class LifecycleManager {
     private static final Logger LOG = LoggerFactory.getLogger(LifecycleManager.class);
     
     private final Set<LifecycleListener> listeners = new LinkedHashSet<>();
-    private final AtomicReference<State> state = new AtomicReference<>(State.Starting);
+    private final AtomicReference<State> state;
     private volatile Throwable failureReason;
     
     public enum State {
@@ -33,11 +35,16 @@ public final class LifecycleManager {
         Done
     }
     
+    public LifecycleManager() {        
+        LOG.info("Starting '{}'", this);
+        state = new AtomicReference<>(State.Starting);               
+    }
+    
     public synchronized void addListener(LifecycleListener listener) {
         listener = SafeLifecycleListener.wrap(listener);
         
         if (!listeners.contains(listener) && listeners.add(listener)) {
-            LOG.info("Adding LifecycleListener '{}' {}", listener, System.identityHashCode(listener));
+            LOG.info("Adding listener '{}'", listener);
             switch (state.get()) {
             case Started:
                 listener.onStarted();
@@ -53,29 +60,33 @@ public final class LifecycleManager {
     
     public synchronized void notifyStarted() {
         if (state.compareAndSet(State.Starting, State.Started)) {
+            LOG.info("Started '{}'", this);
             for (LifecycleListener listener : listeners) {
                 listener.onStarted();
             }
         }
     }
     
-    public synchronized void notifyStartFailed(Throwable t) {
-        if (state.compareAndSet(State.Starting, State.Stopped)) {
-            failureReason = t;
-            LifecycleListener[] asArray = listeners.toArray(new LifecycleListener[0]);
-            for (int i=asArray.length-1; i >=0; i--) {
-                asArray[i].onStopped(t);
+    public synchronized void notifyStartFailed(final Throwable t) {
+        // State.Started added here to allow for failure  when LifecycleListener.onStarted() is called, post-injector creation
+        if (state.compareAndSet(State.Starting, State.Stopped) || state.compareAndSet(State.Started, State.Stopped)) {
+            LOG.info("Failed start of '{}'", this);
+            this.failureReason = t;
+            Iterator<LifecycleListener> shutdownIter = new LinkedList<>(listeners).descendingIterator();
+            while (shutdownIter.hasNext()) {
+                shutdownIter.next().onStopped(t);
             }
         }
     }
     
     public synchronized void notifyShutdown() {
-        if (state.compareAndSet(State.Started, State.Done)) {
-            LOG.info("Shutting down LifecycleManager");
-            LifecycleListener[] asArray = listeners.toArray(new LifecycleListener[0]);
-            for (int i=asArray.length-1; i >=0; i--) {
-                asArray[i].onStopped(null);
+        if (state.compareAndSet(State.Started, State.Stopped)) {
+            LOG.info("Stopping '{}'", this);
+            Iterator<LifecycleListener> shutdownIter = new LinkedList<>(listeners).descendingIterator();
+            while (shutdownIter.hasNext()) {
+                shutdownIter.next().onStopped(null);
             }
+            state.set(State.Done);
         }
     }
     
@@ -85,5 +96,10 @@ public final class LifecycleManager {
     
     public Throwable getFailureReason() {
         return failureReason;
+    }
+
+    @Override
+    public String toString() {
+        return "LifecycleManager@" + System.identityHashCode(this);
     }
 }

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -170,14 +170,14 @@ public final class LifecycleModule extends AbstractModule {
                                     m.call(injectee);
                                 } 
                                 catch (Exception e) {
-                                    LOG.error(String.format("Exception thrown by action %s [%s]", m, bindingSource), e);
+                                    LOG.error("Exception thrown by action {} [{}]", m, bindingSource, e);
                                 }
                             }
                         }
                     });
                 }
                 else {
-                    LOG.warn("Already shutting down.  Shutdown methods {} on {} will not be invoked", new Object[]{actions.preDestroyActions, injectee.getClass().getName()});
+                    LOG.warn("Already shutting down.  Shutdown methods {} on {} will not be invoked", actions.preDestroyActions, injectee.getClass().getName());
                 }
             }
         }

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -23,7 +23,6 @@ import com.netflix.governator.annotations.SuppressLifecycleUninitialized;
 import com.netflix.governator.internal.GovernatorFeatureSet;
 import com.netflix.governator.internal.PostConstructLifecycleActions;
 import com.netflix.governator.internal.PreDestroyLifecycleActions;
-import com.netflix.governator.spi.LifecycleListener;
 
 /**
  * Adds support for standard lifecycle annotations @PostConstruct and @PreDestroy to Guice.
@@ -87,7 +86,7 @@ public final class LifecycleModule extends AbstractModule {
             provisionListener.features = features;
             provisionListener.shutdownOnFailure =  args.hasShutdownOnFailure();
             
-            LOG.debug("LifecycleProvisionListener initialized {}", features);
+            LOG.debug("LifecycleProvisionListener initialized with features {}", features);
         }
         
         public TypeLifecycleActions getOrCreateActions(Class<?> type) {
@@ -129,7 +128,7 @@ public final class LifecycleModule extends AbstractModule {
         
         @Override
         public String toString() {
-            return "LifecycleProvisionListener[]";
+            return "LifecycleProvisionListener@" + System.identityHashCode(this);
         }
 
         @Override
@@ -147,6 +146,7 @@ public final class LifecycleModule extends AbstractModule {
                 return;
             }
             
+            final Object bindingSource = provision.getBinding().getSource();
             final TypeLifecycleActions actions = getOrCreateActions(injectee.getClass());
             
             // Call all the LifecycleActions with PostConstruct methods being the last 
@@ -155,7 +155,7 @@ public final class LifecycleModule extends AbstractModule {
                     action.call(injectee);
                 } 
                 catch (Exception e) {
-                    throw new ProvisionException("Failed to provision object of type " + injectee.getClass(), e);
+                    throw new ProvisionException("Exception thrown by action %s " + action + " [" + bindingSource + "]", e);
                 }
             }
             
@@ -170,7 +170,7 @@ public final class LifecycleModule extends AbstractModule {
                                     m.call(injectee);
                                 } 
                                 catch (Exception e) {
-                                    LOG.error("Failed to call @PreDestroy method {} on {}", new Object[]{m, injectee.getClass().getName()}, e);
+                                    LOG.error(String.format("Exception thrown by action %s [%s]", m, bindingSource), e);
                                 }
                             }
                         }
@@ -203,6 +203,6 @@ public final class LifecycleModule extends AbstractModule {
 
     @Override
     public String toString() {
-        return "LifecycleModule[]";
+        return "LifecycleModule@" + System.identityHashCode(this);
     }
 }

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -21,8 +21,8 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.spi.ProvisionListener;
 import com.netflix.governator.annotations.SuppressLifecycleUninitialized;
 import com.netflix.governator.internal.GovernatorFeatureSet;
-import com.netflix.governator.internal.PostConstructLifecycleActions;
-import com.netflix.governator.internal.PreDestroyLifecycleActions;
+import com.netflix.governator.internal.PostConstructLifecycleFeature;
+import com.netflix.governator.internal.PreDestroyLifecycleFeature;
 
 /**
  * Adds support for standard lifecycle annotations @PostConstruct and @PreDestroy to Guice.
@@ -99,10 +99,10 @@ public final class LifecycleModule extends AbstractModule {
                 }
                 
                 // Finally, add @PostConstruct methods
-                actions.postConstructActions.addAll(PostConstructLifecycleActions.INSTANCE.getActionsForType(type));
+                actions.postConstructActions.addAll(PostConstructLifecycleFeature.INSTANCE.getActionsForType(type));
                 
                 // Determine @PreDestroy methods
-                actions.preDestroyActions.addAll(PreDestroyLifecycleActions.INSTANCE.getActionsForType(type));
+                actions.preDestroyActions.addAll(PreDestroyLifecycleFeature.INSTANCE.getActionsForType(type));
                 
                 TypeLifecycleActions existing = cache.putIfAbsent(type, actions);
                 if (existing != null) {

--- a/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
@@ -32,7 +32,7 @@ final class SafeLifecycleListener implements LifecycleListener {
     @Override
     public void onStopped(Throwable t) {
         if (t != null) {
-            LOG.info(String.format("Stopping '%s' due to '%s@%d'", delegate, t.getClass().getSimpleName(), System.identityHashCode(t)));
+            LOG.info("Stopping '{}' due to '{}@{}'", delegate, t.getClass().getSimpleName(), System.identityHashCode(t));
         }
         else {
             LOG.info("Stopping '{}'", delegate);            

--- a/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
@@ -59,7 +59,7 @@ final class SafeLifecycleListener implements LifecycleListener {
         if (getClass() != obj.getClass())
             return false;
         SafeLifecycleListener other = (SafeLifecycleListener) obj;
-        return !delegate.equals(other.delegate);
+        return delegate == other.delegate || delegate.equals(other.delegate);
     }
     
 

--- a/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import com.netflix.governator.spi.LifecycleListener;
 
 /**
- * Wrapper for any LifecycleListener to provide this following funcionality
+ * Wrapper for any LifecycleListener to provide this following functionality
  * 1.  Logging of events as INFO
  * 2.  Swallow any event handler exceptions during shutdown
  */
@@ -25,24 +25,29 @@ final class SafeLifecycleListener implements LifecycleListener {
     
     @Override
     public void onStarted() {
-        LOG.info("Starting LifecycleListener '{}'", delegate);
+        LOG.info("Starting '{}'", delegate);
         delegate.onStarted();
     }
 
     @Override
     public void onStopped(Throwable t) {
-        LOG.info("Stopping LifecycleListener '{}'", delegate, t);
+        if (t != null) {
+            LOG.info(String.format("Stopping '%s' due to '%s@%d'", delegate, t.getClass().getSimpleName(), System.identityHashCode(t)));
+        }
+        else {
+            LOG.info("Stopping '{}'", delegate);            
+        }
         try {
             delegate.onStopped(t);
         }
         catch (Exception e) {
-            LOG.info("onStopped failed for listener {}", delegate, e);
+            LOG.info("onStopped failed for {}", delegate, e);
         }
     }
 
     @Override
     public String toString() {
-        return "Safe[" + delegate.toString() + "]";
+        return "SafeLifecycleListener@" + System.identityHashCode(this) + " [" + delegate.toString() + "]";
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/JSR250LifecycleAction.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/JSR250LifecycleAction.java
@@ -1,0 +1,78 @@
+package com.netflix.governator.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.governator.LifecycleAction;
+
+public class JSR250LifecycleAction implements LifecycleAction {
+    private static final Logger LOG = LoggerFactory.getLogger(JSR250LifecycleAction.class);
+    private final Method method;
+    private final String description;
+
+    public JSR250LifecycleAction(Class<? extends Annotation> annotationClass, Method method) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            throw new IllegalArgumentException("method must not be static");
+        } else if (method.getParameterCount() > 0) {
+            throw new IllegalArgumentException("method parameter count must be zero");
+        } else if (Void.TYPE != method.getReturnType()) {
+            throw new IllegalArgumentException("method must have void return type");
+        } else if (method.getExceptionTypes().length > 0) {
+            for (Class<?> e : method.getExceptionTypes()) {
+                if (!RuntimeException.class.isAssignableFrom(e)) {
+                    throw new IllegalArgumentException(
+                            "method must must not throw checked exception: " + e.getSimpleName());
+                }
+            }
+        } else {
+            int preDestroyCount = 0;
+            for (Method m : method.getDeclaringClass().getDeclaredMethods()) {
+                if (m.isAnnotationPresent(annotationClass)) {
+                    preDestroyCount++;
+                }
+            }
+            if (preDestroyCount > 1) {
+                throw new IllegalArgumentException(
+                        "declaring class must not contain multiple @" + annotationClass.getSimpleName() + " methods");
+            }
+        }
+
+        if (!method.isAccessible()) {
+            method.setAccessible(true);
+        }
+        this.method = method;
+        this.description = String.format("%s@%d[%s.%s()]", annotationClass.getSimpleName(),
+                System.identityHashCode(this), method.getDeclaringClass().getSimpleName(), method.getName());
+    }
+
+    @Override
+    public void call(Object obj) throws InvocationTargetException {
+        LOG.debug("calling action {}", description);
+        try {
+            method.invoke(obj);
+        } catch (InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw ite;
+        }
+        catch (IllegalAccessException | IllegalArgumentException e) {
+            // extremely unlikely, as constructor sets the method to 'accessible' and validates that it takes no parameters
+            throw new RuntimeException("unexpected exception in method invocation", e);
+        }
+     }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+
+}

--- a/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleActions.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleActions.java
@@ -116,18 +116,7 @@ public final class PostConstructLifecycleActions implements LifecycleFeature {
         public void call(Object obj)
                 throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
             LOG.debug("calling action {}", description);
-            try {
-                method.invoke(obj);
-            } catch (InvocationTargetException ite) {
-                Throwable cause = ite.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException)cause;
-                }
-                else if (cause instanceof Error) {
-                    throw (Error)cause;
-                }
-                throw ite;
-            }
+            TypeInspector.invoke(method, obj);
         }
 
         @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleActions.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleActions.java
@@ -81,7 +81,7 @@ public final class PostConstructLifecycleActions implements LifecycleFeature {
                         // order the members in the list, so superclass
                         // @PostContruct actions are first
                         PostConstructAction postConstructAction = new PostConstructAction(method);
-                        LOG.debug("adding lifecycle action for {}", postConstructAction.description);
+                        LOG.debug("adding action {}", postConstructAction.description);
                         this.typeActions.addFirst(postConstructAction);
                         visitContext.add(methodName);
                     }
@@ -108,15 +108,26 @@ public final class PostConstructLifecycleActions implements LifecycleFeature {
 
         private PostConstructAction(Method method) {
             this.method = method;
-            this.description = new StringBuilder().append("PostConstruct[").append(method.getDeclaringClass().getName())
-                    .append("#").append(method.getName()).append("]").toString();
+            this.description = new StringBuilder().append("PostConstruct@").append(System.identityHashCode(this)).append("[").append(method.getDeclaringClass().getName())
+                    .append(".").append(method.getName()).append("()]").toString();
         }
 
         @Override
         public void call(Object obj)
                 throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-            LOG.debug("invoking lifecycle action {}", description);
-            method.invoke(obj);
+            LOG.debug("calling action {}", description);
+            try {
+                method.invoke(obj);
+            } catch (InvocationTargetException ite) {
+                Throwable cause = ite.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException)cause;
+                }
+                else if (cause instanceof Error) {
+                    throw (Error)cause;
+                }
+                throw ite;
+            }
         }
 
         @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleFeature.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PostConstructLifecycleFeature.java
@@ -26,11 +26,11 @@ import com.netflix.governator.internal.TypeInspector.TypeVisitor;
  * 
  * @author elandau
  */
-public final class PostConstructLifecycleActions implements LifecycleFeature {
-    private static final Logger LOG = LoggerFactory.getLogger(PostConstructLifecycleActions.class);
-    public static PostConstructLifecycleActions INSTANCE = new PostConstructLifecycleActions();
+public final class PostConstructLifecycleFeature implements LifecycleFeature {
+    private static final Logger LOG = LoggerFactory.getLogger(PostConstructLifecycleFeature.class);
+    public static PostConstructLifecycleFeature INSTANCE = new PostConstructLifecycleFeature();
 
-    private PostConstructLifecycleActions() {
+    private PostConstructLifecycleFeature() {
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleActions.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleActions.java
@@ -123,18 +123,7 @@ public final class PreDestroyLifecycleActions implements LifecycleFeature {
         public void call(Object obj)
                 throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
             LOG.debug("calling action {}", description);
-            try {
-                method.invoke(obj);
-            } catch (InvocationTargetException ite) {
-                Throwable cause = ite.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException)cause;
-                }
-                else if (cause instanceof Error) {
-                    throw (Error)cause;
-                }
-                throw ite;
-            }
+            TypeInspector.invoke(method, obj);
         }
 
         @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleFeature.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleFeature.java
@@ -27,11 +27,11 @@ import com.netflix.governator.internal.TypeInspector.TypeVisitor;
  * 
  * @author elandau
  */
-public final class PreDestroyLifecycleActions implements LifecycleFeature {
-    private static final Logger LOG = LoggerFactory.getLogger(PreDestroyLifecycleActions.class);
-    public static PreDestroyLifecycleActions INSTANCE = new PreDestroyLifecycleActions();
+public final class PreDestroyLifecycleFeature implements LifecycleFeature {
+    private static final Logger LOG = LoggerFactory.getLogger(PreDestroyLifecycleFeature.class);
+    public static PreDestroyLifecycleFeature INSTANCE = new PreDestroyLifecycleFeature();
 
-    private PreDestroyLifecycleActions() {
+    private PreDestroyLifecycleFeature() {
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/TypeInspector.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/TypeInspector.java
@@ -1,6 +1,7 @@
 package com.netflix.governator.internal;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import com.google.common.base.Supplier;
@@ -61,6 +62,31 @@ public class TypeInspector {
             }
         }
         return continueVisit;
+    }
+    
+    /**
+     * convenience method for invoking a reflected method with no parameters and return type 'void'
+     * 
+     * @param noArgsMethod
+     * @param instance
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
+     * @throws InvocationTargetException
+     */
+    public static void invoke(Method noArgsMethod, Object instance) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        try {
+            noArgsMethod.invoke(instance);
+        } catch (InvocationTargetException ite) {
+            Throwable cause = ite.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException)cause;
+            }
+            else if (cause instanceof Error) {
+                throw (Error)cause;
+            }
+            throw ite;
+        }
+
     }
 
 }

--- a/governator-core/src/main/java/com/netflix/governator/internal/TypeInspector.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/TypeInspector.java
@@ -1,7 +1,6 @@
 package com.netflix.governator.internal;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import com.google.common.base.Supplier;
@@ -62,31 +61,6 @@ public class TypeInspector {
             }
         }
         return continueVisit;
-    }
-    
-    /**
-     * convenience method for invoking a reflected method with no parameters and return type 'void'
-     * 
-     * @param noArgsMethod
-     * @param instance
-     * @throws IllegalAccessException
-     * @throws IllegalArgumentException
-     * @throws InvocationTargetException
-     */
-    public static void invoke(Method noArgsMethod, Object instance) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-        try {
-            noArgsMethod.invoke(instance);
-        } catch (InvocationTargetException ite) {
-            Throwable cause = ite.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException)cause;
-            }
-            else if (cause instanceof Error) {
-                throw (Error)cause;
-            }
-            throw ite;
-        }
-
     }
 
 }

--- a/governator-core/src/test/java/com/netflix/governator/InjectorBuilderTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/InjectorBuilderTest.java
@@ -73,7 +73,7 @@ public class InjectorBuilderTest {
     
     @Test
     public void testKeyTracing() {
-        InjectorBuilder
+        try (LifecycleInjector li = InjectorBuilder
             .fromModule(new AbstractModule() {
                 @Override
                 protected void configure() {
@@ -81,7 +81,7 @@ public class InjectorBuilderTest {
                 }
             })
             .traceEachElement(new KeyTracingVisitor())
-            .createInjector();
+            .createInjector()) {}
     }
     
     @Test

--- a/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
@@ -1,8 +1,8 @@
 package com.netflix.governator;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -12,63 +12,54 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
+import com.google.inject.CreationException;
 import com.google.inject.Injector;
 import com.netflix.governator.spi.LifecycleListener;
 
 public class LifecycleModuleTest {
-    
-    private static final class AssertionErrorListener extends TrackingLifecycleListener {
-        public AssertionErrorListener(String name) {
-            super(name);
+
+    static class TestRuntimeException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public TestRuntimeException() {
+            super();
         }
-        @PreDestroy
-        @Override
-        public void destroyed() {
-            super.destroyed();
-            assertThat(false, equalTo(true));
+
+        public TestRuntimeException(String message) {
+            super(message);
         }
+
     }
 
     private static enum Events {
-        Injected,
-        Initialized,
-        Destroyed,
-        Started,
-        Stopped,
-        Error
+        Injected, Initialized, Destroyed, Started, Stopped, Error
     }
-    
+
     @Rule
     public final TestName name = new TestName();
-    
+
     static class TrackingLifecycleListener implements LifecycleListener {
         final List<Events> events = new ArrayList<>();
         private String name;
-        
+
         public TrackingLifecycleListener(String name) {
             this.name = name;
         }
-        
+
         @Inject
-        public void initialize(Injector injector) {
+        public void injected(Injector injector) {
             events.add(Events.Injected);
         }
-        
+
         @PostConstruct
         public void initialized() {
             events.add(Events.Initialized);
         }
-        
-        @PreDestroy
-        public void destroyed() {
-            events.add(Events.Destroyed);
-        }
-        
+
         @Override
         public void onStarted() {
             events.add(Events.Started);
@@ -82,60 +73,232 @@ public class LifecycleModuleTest {
             }
         }
 
+        @PreDestroy
+        public void destroyed() {
+            events.add(Events.Destroyed);
+        }
+
         @Override
         public String toString() {
-            return "TrackingLifecycleListener[" + name + "]";
+            return "TrackingLifecycleListener@" + name;
         }
     }
-    
+
     @Test
     public void confirmLifecycleListenerEventsForSuccessfulStart() {
         final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName());
-        
+
         TestSupport.inject(listener).close();
-        
-        assertThat(listener.events, equalTo(Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Destroyed)));
+
+        assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Destroyed)));
     }
-    
-    @Test(expected=RuntimeException.class)
-    public void confirmLifecycleListenerEventsForFailedStart() {
+
+    @Test
+    public void confirmLifecycleListenerEventsForRTExceptionInjected() {
         final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
             @Override
             @Inject
-            public void initialize(Injector injector) {
-                super.initialize(injector);
-                throw new RuntimeException("Failed");
-            } 
+            public void injected(Injector injector) {
+                super.injected(injector);
+                throw new TestRuntimeException("injected failed");
+            }
         };
-        
-        try (LifecycleInjector injector = TestSupport.inject(listener)){
-        }
-        finally {
+
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected exception injecting instance");
+        } catch (CreationException e) {
+            // expected
+        } catch (Exception e) {
+            fail("expected CreationException injecting instance but got " + e);
+        } finally {
             assertThat(listener.events, equalTo(Arrays.asList(Events.Injected)));
         }
     }
     
-    @Ignore // deprecated governator.run() does not invoke lifecycle methods 
-    @Test(expected=AssertionError.class)
-<<<<<<< 31d39215f31ed941452ddfb04d9ea74fd36f7815
-    public void assertionExceptionInListener() {
-        TrackingLifecycleListener listener = new TrackingLifecycleListener() {
+    @Test
+    public void confirmLifecycleListenerEventsForRTExceptionPostConstruct() {
+        final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Override
+            @PostConstruct
+            public void initialized() {
+                super.initialized();
+                throw new TestRuntimeException("postconstruct rt exception");
+            }
+        };
+
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected rt exception starting injector");
+        } catch (CreationException e) {
+            // expected
+        } catch (Exception e) {
+            fail("expected CreationException starting injector but got " + e);
+        } finally {
+            assertThat(listener.events, equalTo(Arrays.asList(Events.Injected, Events.Initialized, Events.Stopped, Events.Error)));
+        }
+    }
+
+    @Test
+    public void confirmLifecycleListenerEventsForRTExceptionOnStarted() {
+        final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Override
+            public void onStarted() {
+                super.onStarted();
+                throw new TestRuntimeException("onStarted rt exception");
+            }
+        };
+
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected rt exception starting injector");
+        } catch (TestRuntimeException e) {
+            // expected
+        } catch (Exception e) {
+            fail("expected TestRuntimeException starting injector but got " + e);
+        } finally {
+            assertThat(listener.events, equalTo(Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Error, Events.Destroyed)));
+        }
+    }
+
+    @Test
+    public void confirmLifecycleListenerEventsForRTExceptionOnStopped() {
+        final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
             @Override
             public void onStopped(Throwable t) {
                 super.onStopped(t);
-                assertThat(t, nullValue());
-                assertThat(false, equalTo(true));
+                throw new TestRuntimeException("onStopped rt exception");
             }
         };
-        try (LifecycleInjector injector = TestSupport.inject(listener)){
+
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+        } finally {
+            assertThat(listener.events, equalTo(Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Destroyed)));
         }
-=======
-    public void assertionErrorInListener() {
-        AssertionErrorListener listener = new AssertionErrorListener(name.getMethodName());
-        LifecycleInjector lifecycleInjector = new Governator().run(listener);
-        lifecycleInjector.getInstance(AssertionErrorListener.class);
-        lifecycleInjector.shutdown();
->>>>>>> ordering for lifecycle listeners, fix equality in SafeLifecycleListener
+    }
+
+    @Test
+    public void confirmLifecycleListenerEventsForRTExceptionPreDestroy() {
+        final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Override
+            public void destroyed() {
+                super.destroyed();
+                throw new TestRuntimeException("destroyed rt exception");
+            }
+        };
+
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+        } finally {
+            assertThat(listener.events, equalTo(Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Destroyed)));
+        }
+    }
+
+    
+
+    @Test(expected=AssertionError.class)
+    public void assertionErrorInInject() {
+        TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Inject
+            @Override
+            public void injected(Injector injector) {
+                super.injected(injector);
+                fail("injected exception");
+            }
+        };
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected error provisioning injector");
+        } catch (Exception e) {
+            fail("expected AssertionError provisioning injector but got " + e);
+        }
+        finally {
+            assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Stopped, Events.Error)));
+        }
+    }
+    
+    
+    @Test(expected=AssertionError.class)
+    public void assertionErrorInPostConstruct() {
+        TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @PostConstruct
+            @Override
+            public void initialized() {
+                super.initialized();
+                fail("postconstruct exception");
+            }
+        };
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected error creating injector");
+        } catch (Exception e) {
+            fail("expected AssertionError destroying injector but got " + e);
+        }
+        finally {
+            assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Stopped, Events.Error)));
+        }
+    }
+    
+    @Test(expected=AssertionError.class)
+    public void assertionErrorInOnStarted() {
+        TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Override
+            public void onStarted() {
+                super.onStarted();
+                fail("onStarted exception");
+            }
+        };
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected AssertionError starting injector");
+        } catch (Exception e) {
+            fail("expected AssertionError starting injector but got " + e);
+        }
+        finally {
+            assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Error)));
+        }
+    }    
+
+    
+    
+    @Test(expected=AssertionError.class)
+    public void assertionErrorInOnStopped() {
+        TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @Override
+            public void onStopped(Throwable t) {
+                super.onStopped(t);
+                fail("onstopped exception");
+            }
+        };
+        try (LifecycleInjector injector = TestSupport.inject(listener)) {
+            fail("expected AssertionError stopping injector");
+        } catch (Exception e) {
+            fail("expected AssertionError stopping injector but got " + e);
+        }
+        finally {
+            assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Stopped, Events.Error)));
+        }
+    }   
+    
+    @Test(expected=AssertionError.class)
+    public void assertionErrorInPreDestroy() {
+        TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @PreDestroy
+            @Override
+            public void destroyed() {
+                super.destroyed();
+                fail("expected exception from predestroy");
+            }
+        };
+        try {
+            TestSupport.inject(listener).close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("expected no exceptions for failed destroy method but got " + e);
+        }
+        finally {
+            assertThat(listener.events, equalTo(
+                Arrays.asList(Events.Injected, Events.Initialized, Events.Started, Events.Stopped, Events.Destroyed)));
+        }
+
     }
 
 }

--- a/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/LifecycleModuleTest.java
@@ -178,6 +178,7 @@ public class LifecycleModuleTest {
     @Test
     public void confirmLifecycleListenerEventsForRTExceptionPreDestroy() {
         final TrackingLifecycleListener listener = new TrackingLifecycleListener(name.getMethodName()) {
+            @PreDestroy
             @Override
             public void destroyed() {
                 super.destroyed();

--- a/governator-core/src/test/java/com/netflix/governator/PostConstructTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/PostConstructTest.java
@@ -1,8 +1,5 @@
 package com.netflix.governator;
 
-import java.lang.reflect.Method;
-import java.util.Arrays;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ release.scope=patch
 
 guice_version=4.0
 hamcrest_version=1.3
+slf4j_version=1.7.2


### PR DESCRIPTION
LifecycleManager uses a HashSet for discovered LifecycleListeners, providing unpredictable invocation order for callback methods.  Changed over to LinkedHashset so that LifecycleListener callbacks are called in same order as the listeners were added.

Added reverse-ordering for calling LifecycleListener.onStopped(), to ensure that listeners have best opportunity to 'tear down' any changes made in LifecycleListener.onStarted().