### PR TITLE
Fix Jetty META-INF/resources discovery issue

### DIFF
--- a/governator-jersey/src/test/java/com/netflix/governator/guice/jetty/JerseyServerTest.java
+++ b/governator-jersey/src/test/java/com/netflix/governator/guice/jetty/JerseyServerTest.java
@@ -52,7 +52,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
+                                return new DefaultJettyConfig().setPort(0);
                             }
                         }))
                         .createInjector();
@@ -94,7 +94,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
+                                return new DefaultJettyConfig().setPort(0);
                             }
                         }))
                         .createInjector();
@@ -137,7 +137,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
+                                return new DefaultJettyConfig().setPort(0);
                             }
                         }))
                         .createInjector();

--- a/governator-jersey/src/test/java/com/netflix/governator/guice/jetty/JerseyServerTest.java
+++ b/governator-jersey/src/test/java/com/netflix/governator/guice/jetty/JerseyServerTest.java
@@ -52,7 +52,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0);
+                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
                             }
                         }))
                         .createInjector();
@@ -94,7 +94,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0);
+                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
                             }
                         }))
                         .createInjector();
@@ -106,7 +106,7 @@ public class JerseyServerTest {
         System.out.println("Listening on port : "+ port);
         
         URL url = new URL(String.format("http://localhost:%d/", port));
-        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         try {
             conn.getResponseCode();
         }
@@ -137,7 +137,7 @@ public class JerseyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0);
+                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
                             }
                         }))
                         .createInjector();

--- a/governator-jetty/build.gradle
+++ b/governator-jetty/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     compile 'com.google.inject.extensions:guice-servlet:4.0'
     compile 'com.sun.jersey:jersey-server:1.19'
     compile 'org.eclipse.jetty:jetty-servlet:9.2.12.v20150709'
+    compile 'org.eclipse.jetty:jetty-webapp:9.2.12.v20150709'
     
     testCompile 'com.sun.jersey.contribs:jersey-guice:1.19'
 }

--- a/governator-jetty/src/main/java/com/netflix/governator/guice/jetty/DefaultJettyConfig.java
+++ b/governator-jetty/src/main/java/com/netflix/governator/guice/jetty/DefaultJettyConfig.java
@@ -5,14 +5,28 @@ import javax.inject.Singleton;
 @Singleton
 public class DefaultJettyConfig implements JettyConfig {
     private int port = 8080;
-    
+
+    // Where static files live. We pass this to Jetty for class path scanning to find the exact directory.
+    // The default is to use resources supported by the servlet 3.0 spec.
+    private String resourceBase = "/META-INF/resources/";
+
     @Override
     public int getPort() {
         return port;
     }
-    
+
+    @Override
+    public String getResourceBase() {
+        return resourceBase;
+    }
+
     public DefaultJettyConfig setPort(int port) {
         this.port = port;
+        return this;
+    }
+
+    public DefaultJettyConfig setResourceBase(String resourceBase) {
+        this.resourceBase = resourceBase;
         return this;
     }
 }

--- a/governator-jetty/src/main/java/com/netflix/governator/guice/jetty/JettyConfig.java
+++ b/governator-jetty/src/main/java/com/netflix/governator/guice/jetty/JettyConfig.java
@@ -3,5 +3,11 @@ package com.netflix.governator.guice.jetty;
 public interface JettyConfig {
 
     int getPort();
+
+    /**
+     * @return The directory where the webapp has the static resources. It can just be a suffix since we'll scan the
+     * classpath to find the exact directory name.
+     */
+    String getResourceBase();
     
 }

--- a/governator-jetty/src/test/java/com/netflix/governator/guice/jetty/JettyServerTest.java
+++ b/governator-jetty/src/test/java/com/netflix/governator/guice/jetty/JettyServerTest.java
@@ -50,7 +50,7 @@ public class JettyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
+                                return new DefaultJettyConfig().setPort(0);
                             }
                         }))
                         .createInjector();

--- a/governator-jetty/src/test/java/com/netflix/governator/guice/jetty/JettyServerTest.java
+++ b/governator-jetty/src/test/java/com/netflix/governator/guice/jetty/JettyServerTest.java
@@ -50,7 +50,7 @@ public class JettyServerTest {
                             @Provides
                             JettyConfig getConfig() {
                                 // Use emphemeral ports
-                                return new DefaultJettyConfig().setPort(0);
+                                return new DefaultJettyConfig().setPort(0).setResourceBase(".");
                             }
                         }))
                         .createInjector();

--- a/governator-jetty/src/test/resources/META-INF/resources/test.txt
+++ b/governator-jetty/src/test/resources/META-INF/resources/test.txt
@@ -1,0 +1,1 @@
+Dummy page so we test that the WebAppContext starts up fine in the JettyModule with the META-INF/resources default.


### PR DESCRIPTION
When multiple META-INF/resources directories existed in
a webapp we only picked the first one resolved.
Now we use the jetty-webapp tooling to scan for all resources.