### PR TITLE
governator performance tuning 

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/LifecycleListenerModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleListenerModule.java
@@ -49,11 +49,7 @@ public final class LifecycleListenerModule extends AbstractModule {
         @Override
         public <T> void onProvision(ProvisionInvocation<T> provision) {
             final T injectee = provision.provision();
-            if (injectee == null) {
-                return;
-            }
-            
-            if (injectee instanceof LifecycleListener) {
+            if (injectee != null && injectee instanceof LifecycleListener) {
                 if (manager == null) {
                     pendingLifecycleListeners.add((LifecycleListener) injectee);
                 } else {
@@ -65,7 +61,7 @@ public final class LifecycleListenerModule extends AbstractModule {
 
     @Override
     public boolean equals(Object obj) {
-        return getClass().equals(obj.getClass());
+        return getClass()==obj.getClass();
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
@@ -108,8 +108,9 @@ public final class LifecycleManager {
         // State.Started added here to allow for failure  when LifecycleListener.onStarted() is called, post-injector creation
         if (state.compareAndSet(State.Starting, State.Stopped) || state.compareAndSet(State.Started, State.Stopped)) {
             LOG.info("Failed start of '{}'", this);
-            running.set(false);
-            reqQueueExecutor.shutdown();
+            if (running.compareAndSet(true, false)) {
+                reqQueueExecutor.shutdown();            
+            }
             this.failureReason = t;
             Iterator<SafeLifecycleListener> shutdownIter = new LinkedList<>(listeners).descendingIterator();
             while (shutdownIter.hasNext()) {
@@ -117,6 +118,7 @@ public final class LifecycleManager {
             }
             listeners.clear();
         }
+        state.set(State.Done);        
     }
     
     public synchronized void notifyShutdown() {

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
@@ -2,6 +2,7 @@ package com.netflix.governator;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -98,7 +99,7 @@ public final class LifecycleManager {
     public synchronized void notifyStarted() {
         if (state.compareAndSet(State.Starting, State.Started)) {
             LOG.info("Started '{}'", this);
-            for (LifecycleListener listener : listeners) {
+            for (LifecycleListener listener : new ArrayList<>(listeners)) {
                 listener.onStarted();
             }
         }

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -20,6 +20,7 @@ import com.google.inject.matcher.Matchers;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.spi.ProvisionListener;
 import com.netflix.governator.annotations.SuppressLifecycleUninitialized;
+import com.netflix.governator.internal.BinaryConstant;
 import com.netflix.governator.internal.GovernatorFeatureSet;
 import com.netflix.governator.internal.JSR250LifecycleAction.ValidationMode;
 import com.netflix.governator.internal.PostConstructLifecycleFeature;
@@ -63,7 +64,7 @@ public final class LifecycleModule extends AbstractModule {
     @Singleton
     @SuppressLifecycleUninitialized
     static class LifecycleProvisionListener extends AbstractLifecycleListener implements ProvisionListener {
-        private final ConcurrentMap<Class<?>, TypeLifecycleActions> cache = new ConcurrentHashMap<>(1<<12);
+        private final ConcurrentMap<Class<?>, TypeLifecycleActions> cache = new ConcurrentHashMap<>(BinaryConstant.I12_4096);
         private Set<LifecycleFeature> features;
         private final AtomicBoolean isShutdown = new AtomicBoolean();
         private PostConstructLifecycleFeature postConstructFeature;

--- a/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleModule.java
@@ -63,7 +63,7 @@ public final class LifecycleModule extends AbstractModule {
     @Singleton
     @SuppressLifecycleUninitialized
     static class LifecycleProvisionListener extends AbstractLifecycleListener implements ProvisionListener {
-        private final ConcurrentMap<Class<?>, TypeLifecycleActions> cache = new ConcurrentHashMap<>();
+        private final ConcurrentMap<Class<?>, TypeLifecycleActions> cache = new ConcurrentHashMap<>(1<<12);
         private Set<LifecycleFeature> features;
         private final AtomicBoolean isShutdown = new AtomicBoolean();
         private PostConstructLifecycleFeature postConstructFeature;

--- a/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
+++ b/governator-core/src/main/java/com/netflix/governator/SafeLifecycleListener.java
@@ -17,7 +17,7 @@ import com.netflix.governator.spi.LifecycleListener;
 final class SafeLifecycleListener extends WeakReference<LifecycleListener> implements LifecycleListener {
     private static final Logger LOG = LoggerFactory.getLogger(SafeLifecycleListener.class);
     private final int delegateHash;
-    private final String delegateString;
+    private final String asString;
 
     public static SafeLifecycleListener wrap(LifecycleListener listener) {
         Preconditions.checkNotNull(listener, "listener argument must be non-null");
@@ -32,7 +32,7 @@ final class SafeLifecycleListener extends WeakReference<LifecycleListener> imple
     private SafeLifecycleListener(LifecycleListener delegate, ReferenceQueue<LifecycleListener> refQueue) {
         super(delegate, refQueue);
         this.delegateHash = delegate.hashCode();
-        this.delegateString = delegate.toString();
+        this.asString = "SafeLifecycleListener@" + System.identityHashCode(this) + " [" + delegate.toString() + "]";
     }
     
     @Override
@@ -65,7 +65,7 @@ final class SafeLifecycleListener extends WeakReference<LifecycleListener> imple
 
     @Override
     public String toString() {
-        return "SafeLifecycleListener@" + System.identityHashCode(this) + " [" + delegateString + "]";
+        return asString;
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/BinaryConstant.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/BinaryConstant.java
@@ -1,0 +1,123 @@
+package com.netflix.governator.internal;
+
+public enum BinaryConstant {
+    B0_1, B1_2, B2_4, B3_8, B4_16, B5_32, B6_64, B7_128, 
+    B8_256, B9_512, B10_1024, B11_2048, B12_4096, B13_8192, B14_16384, B15_32768, B16_65536, 
+    B17_131072, B18_262144, B19_524288, B20_1048576, B21_2097152, B22_4194304, B23_8388608, B24_16777216, 
+    B25_33554432, B26_67108864, B27_134217728, B28_268435456, B29_536870912, B30_1073741824, B31_2147483648, B32_4294967296, 
+    B33_8589934592, B34_17179869184, B35_34359738368, B36_68719476736, B37_137438953472, B38_274877906944, B39_549755813888, B40_1099511627776, B41_2199023255552, B42_4398046511104, 
+    B43_8796093022208, B44_17592186044416, B45_35184372088832, B46_70368744177664, B47_140737488355328, B48_281474976710656, B49_562949953421312, B50_1125899906842624, B51_2251799813685248, B52_4503599627370496, B53_9007199254740992, B54_18014398509481984, B55_36028797018963968, B56_72057594037927936, 
+    B57_144115188075855872, B58_288230376151711744, B59_576460752303423488, B60_1152921504606846976, B61_2305843009213693952, B62_4611686018427387904, B63_N9223372036854775808;
+
+    private final long value;
+    private final String msg;
+
+    private BinaryConstant() {
+        this.value = 1L << ordinal();
+        this.msg = name() + "(2^" + ordinal() + "=" + value + ")";
+    }
+
+    public String toString() {
+        return msg;
+    }
+    
+    public static final int I0_1 = 1;
+    public static final int I1_2 = 2;
+    public static final int I2_4 = 4;
+    public static final int I3_8 = 8;
+    public static final int I4_16 = 16;
+    public static final int I5_32 = 32;
+    public static final int I6_64 = 64;
+    public static final int I7_128 = 128;
+    public static final int I8_256 = 256;
+    public static final int I9_512 = 512;
+    public static final int I10_1024 = 1024;
+    public static final int I11_2048 = 2048;
+    public static final int I12_4096 = 4096;
+    public static final int I13_8192 = 8192;
+    public static final int I14_16384 = 16384;
+    public static final int I15_32768 = 32768;
+    public static final int I16_65536 = 65536;
+    public static final int I17_131072 = 131072;
+    public static final int I18_262144 = 262144;
+    public static final int I19_524288 = 524288;
+    public static final int I20_1048576 = 1048576;
+    public static final int I21_2097152 = 2097152;
+    public static final int I22_4194304 = 4194304;
+    public static final int I23_8388608 = 8388608;
+    public static final int I24_16777216 = 16777216;
+    public static final int I25_33554432 = 33554432;
+    public static final int I26_67108864 = 67108864;
+    public static final int I27_134217728 = 134217728;
+    public static final int I28_268435456 = 268435456;
+    public static final int I29_536870912 = 536870912;
+    public static final int I30_1073741824 = 1073741824;
+    public static final int I31_2147483648 = -2147483648;
+    
+    public static final long L0_1 = 1L;
+    public static final long L1_2 = 2L;
+    public static final long L2_4 = 4L;
+    public static final long L3_8 = 8L;
+    public static final long L4_16 = 16L;
+    public static final long L5_32 = 32L;
+    public static final long L6_64 = 64L;
+    public static final long L7_128 = 128L;
+    public static final long L8_256 = 256L;
+    public static final long L9_512 = 512L;
+    public static final long L10_1024 = 1024L;
+    public static final long L11_2048 = 2048L;
+    public static final long L12_4096 = 4096L;
+    public static final long L13_8192 = 8192L;
+    public static final long L14_16384 = 16384L;
+    public static final long L15_32768 = 32768L;
+    public static final long L16_65536 = 65536L;
+    public static final long L17_131072 = 131072L;
+    public static final long L18_262144 = 262144L;
+    public static final long L19_524288 = 524288L;
+    public static final long L20_1048576 = 1048576L;
+    public static final long L21_2097152 = 2097152L;
+    public static final long L22_4194304 = 4194304L;
+    public static final long L23_8388608 = 8388608L;
+    public static final long L24_16777216 = 16777216L;
+    public static final long L25_33554432 = 33554432L;
+    public static final long L26_67108864 = 67108864L;
+    public static final long L27_134217728 = 134217728L;
+    public static final long L28_268435456 = 268435456L;
+    public static final long L29_536870912 = 536870912L;
+    public static final long L30_1073741824 = 1073741824L;
+    public static final long L31_2147483648 = 2147483648L;
+    public static final long L32_4294967296 = 4294967296L;
+    public static final long L33_8589934592 = 8589934592L;
+    public static final long L34_17179869184 = 17179869184L;
+    public static final long L35_34359738368 = 34359738368L;
+    public static final long L36_68719476736 = 68719476736L;
+    public static final long L37_137438953472 = 137438953472L;
+    public static final long L38_274877906944 = 274877906944L;
+    public static final long L39_549755813888 = 549755813888L;
+    public static final long L40_1099511627776 = 1099511627776L;
+    public static final long L41_2199023255552 = 2199023255552L;
+    public static final long L42_4398046511104 = 4398046511104L;
+    public static final long L43_8796093022208 = 8796093022208L;
+    public static final long L44_17592186044416 = 17592186044416L;
+    public static final long L45_35184372088832 = 35184372088832L;
+    public static final long L46_70368744177664 = 70368744177664L;
+    public static final long L47_140737488355328 = 140737488355328L;
+    public static final long L48_281474976710656 = 281474976710656L;
+    public static final long L49_562949953421312 = 562949953421312L;
+    public static final long L50_1125899906842624 = 1125899906842624L;
+    public static final long L51_2251799813685248 = 2251799813685248L;
+    public static final long L52_4503599627370496 = 4503599627370496L;
+    public static final long L53_9007199254740992 = 9007199254740992L;
+    public static final long L54_18014398509481984 = 18014398509481984L;
+    public static final long L55_36028797018963968 = 36028797018963968L;
+    public static final long L56_72057594037927936 = 72057594037927936L;
+    public static final long L57_144115188075855872 = 144115188075855872L;
+    public static final long L58_288230376151711744 = 288230376151711744L;
+    public static final long L59_576460752303423488 = 576460752303423488L;
+    public static final long L60_1152921504606846976 = 1152921504606846976L;
+    public static final long L61_2305843009213693952 = 2305843009213693952L;
+    public static final long L62_4611686018427387904 = 4611686018427387904L;
+    public static final long L63_N9223372036854775808 = -9223372036854775808L;
+    
+
+}

--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleFeature.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyLifecycleFeature.java
@@ -38,7 +38,7 @@ public final class PreDestroyLifecycleFeature implements LifecycleFeature {
     
     @Override
     public List<LifecycleAction> getActionsForType(final Class<?> type) {
-        return TypeInspector.accept(type, new PreDestroyVisitor());
+       return TypeInspector.accept(type, new PreDestroyVisitor());
     }
 
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
@@ -35,59 +35,59 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Monitors managed instances and invokes cleanup actions when they
- * become unreferenced
+ * Monitors managed instances and invokes cleanup actions when they become unreferenced
  * 
  * @author tcellucci
  *
  */
 public class PreDestroyMonitor implements AutoCloseable {
     private static Logger LOGGER = LoggerFactory.getLogger(PreDestroyMonitor.class);
-    
     private static class ScopeCleanupMarker {
         static final Key<ScopeCleanupMarker> MARKER_KEY = Key.get(ScopeCleanupMarker.class);
         // simple id uses identity equality
         private final Object id = new Object();
         private final ScopeCleanupAction cleanupAction;
-        
+
         public ScopeCleanupMarker(ReferenceQueue<ScopeCleanupMarker> markerReferenceQueue) {
             this.cleanupAction = new ScopeCleanupAction(this, markerReferenceQueue);
         }
+
         Object getId() {
             return id;
         }
+
         public ScopeCleanupAction getCleanupAction() {
             return cleanupAction;
         }
     }
 
     static final class ScopeCleaner implements Provider<ScopeCleanupMarker> {
-        ConcurrentMap<Object, ScopeCleanupAction> scopedCleanupActions = new ConcurrentHashMap<>(1<<14);
+        ConcurrentMap<Object, ScopeCleanupAction> scopedCleanupActions = new ConcurrentHashMap<>(BinaryConstant.I14_16384);
         ReferenceQueue<ScopeCleanupMarker> markerReferenceQueue = new ReferenceQueue<>();
-        final ExecutorService reqQueueExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setDaemon(true).setNameFormat("predestroy-monitor-%d").build());
-        final AtomicBoolean running= new AtomicBoolean(true);
+        final ExecutorService reqQueueExecutor = Executors.newSingleThreadExecutor(
+                new ThreadFactoryBuilder().setDaemon(true).setNameFormat("predestroy-monitor-%d").build());
+        final AtomicBoolean running = new AtomicBoolean(true);
         final ScopeCleanupMarker singletonMarker = get();
-        
-        
+
         {
             this.reqQueueExecutor.submit(new ScopedCleanupWorker());
         }
-        
+
         @Override
         public ScopeCleanupMarker get() {
             ScopeCleanupMarker marker = new ScopeCleanupMarker(markerReferenceQueue);
             scopedCleanupActions.put(marker.getId(), marker.getCleanupAction());
             return marker;
         }
-        
+
         public boolean isRunning() {
             return running.get();
         }
-        
+
         public boolean close() throws Exception {
             boolean rv = running.compareAndSet(true, false);
             if (rv) {
-                reqQueueExecutor.shutdown(); // executor to stop 
+                reqQueueExecutor.shutdown(); // executor to stop
                 // process any remaining scoped cleanup actions
                 List<ScopeCleanupAction> values = new ArrayList<>(scopedCleanupActions.values());
                 scopedCleanupActions.clear();
@@ -105,59 +105,61 @@ public class PreDestroyMonitor implements AutoCloseable {
             }
             return rv;
         }
-        
+
         /**
-         * Processes unreferenced markers from the referenceQueue, until
-         * the 'running' flag is false or interrupted
+         * Processes unreferenced markers from the referenceQueue, until the 'running' flag is false or interrupted
          * 
          */
         final class ScopedCleanupWorker implements Runnable {
             public void run() {
                 try {
                     while (running.get()) {
-                            Reference<? extends ScopeCleanupMarker> ref = markerReferenceQueue.remove(1000);
-                            if (ref != null && ref instanceof ScopeCleanupAction) { 
-                                Object markerKey = ((ScopeCleanupAction)ref).getId();
-                                ScopeCleanupAction cleanupAction = scopedCleanupActions.remove(markerKey);
-                                if (cleanupAction != null) {
-                                    cleanupAction.call();
-                                }
+                        Reference<? extends ScopeCleanupMarker> ref = markerReferenceQueue.remove(1000);
+                        if (ref != null && ref instanceof ScopeCleanupAction) {
+                            Object markerKey = ((ScopeCleanupAction) ref).getId();
+                            ScopeCleanupAction cleanupAction = scopedCleanupActions.remove(markerKey);
+                            if (cleanupAction != null) {
+                                cleanupAction.call();
                             }
+                        }
                     }
                     LOGGER.info("PreDestroyMonitor.ScopedCleanupWorker is exiting");
-                } 
-                catch (InterruptedException e) {
+                } catch (InterruptedException e) {
                     LOGGER.info("PreDestroyMonitor.ScopedCleanupWorker is exiting due to thread interrupt");
-                }                
+                    Thread.currentThread().interrupt(); // clear interrupted status
+                }
             }
         }
-        
+
     }
-    
+
     private Deque<Callable<Void>> cleanupActions = new ConcurrentLinkedDeque<>();
     private ScopeCleaner scopeCleaner = new ScopeCleaner();
-    
+
     Map<Class<? extends Annotation>, Scope> scopeBindings;
-    
+
     public PreDestroyMonitor(Map<Class<? extends Annotation>, Scope> scopeBindings) {
         this.scopeBindings = new HashMap<>(scopeBindings);
     }
-    
+
     public <T> boolean register(T destroyableInstance, Binding<T> binding, Iterable<LifecycleAction> action) {
-        return scopeCleaner.isRunning() ? binding.acceptScopingVisitor(new ManagedInstanceScopingVisitor(destroyableInstance, binding.getSource(), action)) : false;
+        return scopeCleaner.isRunning() ? binding.acceptScopingVisitor(
+                new ManagedInstanceScopingVisitor(destroyableInstance, binding.getSource(), action)) : false;
     }
-    
+
     /*
      * compatibility-mode - scope is assumed to be eager singleton
      */
     public <T> boolean register(T destroyableInstance, Object context, Iterable<LifecycleAction> action) {
-        return scopeCleaner.isRunning() ? new ManagedInstanceScopingVisitor(destroyableInstance, context, action).visitEagerSingleton() : false;
+        return scopeCleaner.isRunning()
+                ? new ManagedInstanceScopingVisitor(destroyableInstance, context, action).visitEagerSingleton() : false;
     }
 
     /**
      * allows late-binding of scopes to PreDestroyMonitor, useful if more than one Injector contributes scope bindings
      * 
-     * @param bindings additional annotation-to-scope bindings to add
+     * @param bindings
+     *            additional annotation-to-scope bindings to add
      */
     public void addScopeBindings(Map<Class<? extends Annotation>, Scope> bindings) {
         if (scopeCleaner.isRunning()) {
@@ -172,10 +174,10 @@ public class PreDestroyMonitor implements AutoCloseable {
     public void close() throws Exception {
         if (scopeCleaner.close()) { // executor thread to exit processing loop
             LOGGER.info("closing PreDestroyMonitor...");
-            
+
             for (Callable<Void> action : cleanupActions) {
                 action.call();
-            }     
+            }
             cleanupActions.clear();
             scopeBindings.clear();
             scopeBindings = Collections.emptyMap();
@@ -184,19 +186,20 @@ public class PreDestroyMonitor implements AutoCloseable {
             LOGGER.warn("PreDestroyMonitor.close() invoked but instance is not running");
         }
     }
-    
+
     /**
-     * visits bindingScope of managed instance to set up an appropriate strategy for cleanup,
-     * adding actions to either the scopedCleanupActions map or cleanupActions list.  Returns
-     * true if cleanup actions were added, false if no cleanup strategy was selected.
-     *  
+     * visits bindingScope of managed instance to set up an appropriate strategy for cleanup, adding actions to either
+     * the scopedCleanupActions map or cleanupActions list. Returns true if cleanup actions were added, false if no
+     * cleanup strategy was selected.
+     * 
      */
-    private final class ManagedInstanceScopingVisitor implements BindingScopingVisitor<Boolean> {       
+    private final class ManagedInstanceScopingVisitor implements BindingScopingVisitor<Boolean> {
         private final Object injectee;
         private final Object context;
         private final Iterable<LifecycleAction> lifecycleActions;
 
-        private ManagedInstanceScopingVisitor(Object injectee, Object context, Iterable<LifecycleAction> lifecycleActions) {
+        private ManagedInstanceScopingVisitor(Object injectee, Object context,
+                Iterable<LifecycleAction> lifecycleActions) {
             this.injectee = injectee;
             this.context = context;
             this.lifecycleActions = lifecycleActions;
@@ -207,13 +210,14 @@ public class PreDestroyMonitor implements AutoCloseable {
          * 
          */
         @Override
-        public Boolean visitEagerSingleton() {           
-            cleanupActions.addFirst(new ManagedInstanceAction(injectee, lifecycleActions)); // no need for scopedCleanupActions, return the task directly
+        public Boolean visitEagerSingleton() {
+            cleanupActions.addFirst(new ManagedInstanceAction(injectee, lifecycleActions)); 
             return true;
         }
 
         /*
-         * use ScopeCleanupMarker dereferencing strategy to detect scope closure, add new entry to scopedCleanupActions map
+         * use ScopeCleanupMarker dereferencing strategy to detect scope closure, add new entry to scopedCleanupActions
+         * map
          * 
          */
         @Override
@@ -234,7 +238,7 @@ public class PreDestroyMonitor implements AutoCloseable {
          * 
          */
         @Override
-        public Boolean visitScopeAnnotation(final Class<? extends Annotation> scopeAnnotation) {                            
+        public Boolean visitScopeAnnotation(final Class<? extends Annotation> scopeAnnotation) {
             Scope scope = scopeBindings.get(scopeAnnotation);
             boolean rv;
             if (scope != null) {
@@ -248,63 +252,66 @@ public class PreDestroyMonitor implements AutoCloseable {
         }
 
         /*
-         *  add a soft-reference ManagedInstanceAction to cleanupActions deque.  Cleanup triggered only at injector shutdown
-         *  if referent has not yet been collected.
+         * add a soft-reference ManagedInstanceAction to cleanupActions deque. Cleanup triggered only at injector
+         * shutdown if referent has not yet been collected.
          * 
          */
         @Override
         public Boolean visitNoScoping() {
-            cleanupActions.addFirst(new ManagedInstanceAction(new SoftReference<Object>(injectee), context, lifecycleActions));  
+            cleanupActions.addFirst(
+                    new ManagedInstanceAction(new SoftReference<Object>(injectee), context, lifecycleActions));
             return true;
         }
     }
 
-      /**
-      * Runnable that weakly references a scopeCleanupMarker and strongly references a list of delegate runnables.  When the marker 
-      * is unreferenced, delegates will be invoked in the reverse order of addition.
-      */
-     private static final class ScopeCleanupAction extends WeakReference<ScopeCleanupMarker> implements Callable<Void>, Comparable<ScopeCleanupAction> {
-         private volatile static long instanceCounter = 0;
-         private final Object id;
-         private final long ordinal;
-         private Deque<Object[]> delegates = new ConcurrentLinkedDeque<>();
-         private final AtomicBoolean complete = new AtomicBoolean(false);
-         
-         public ScopeCleanupAction(ScopeCleanupMarker marker, ReferenceQueue<ScopeCleanupMarker> refQueue) {
-             super(marker, refQueue);
-             this.id = marker.getId();            
-             this.ordinal = instanceCounter++;
-         }
-         
-         public Object getId() {
-             return id;
-         }
-         
-         public void add(Provider<ScopeCleanupMarker> scopeProvider, Callable<Void> action) {
-             if (!complete.get()) {
-                 delegates.addFirst(new Object[] {action, scopeProvider});  // add first
-             }
-         }
-    
-         @Override
-         public Void call() {
-             if (complete.compareAndSet(false, true) && delegates != null) {
-                 for (Object[] r : delegates) {
-                     try {
-                        ((Callable<Void>)r[0]).call();
+    /**
+     * Runnable that weakly references a scopeCleanupMarker and strongly references a list of delegate runnables. When
+     * the marker is unreferenced, delegates will be invoked in the reverse order of addition.
+     */
+    private static final class ScopeCleanupAction extends WeakReference<ScopeCleanupMarker>
+            implements Callable<Void>, Comparable<ScopeCleanupAction> {
+        private volatile static long instanceCounter = 0;
+        private final Object id;
+        private final long ordinal;
+        private Deque<Object[]> delegates = new ConcurrentLinkedDeque<>();
+        private final AtomicBoolean complete = new AtomicBoolean(false);
+
+        public ScopeCleanupAction(ScopeCleanupMarker marker, ReferenceQueue<ScopeCleanupMarker> refQueue) {
+            super(marker, refQueue);
+            this.id = marker.getId();
+            this.ordinal = instanceCounter++;
+        }
+
+        public Object getId() {
+            return id;
+        }
+
+        public void add(Provider<ScopeCleanupMarker> scopeProvider, Callable<Void> action) {
+            if (!complete.get()) {
+                delegates.addFirst(new Object[] { action, scopeProvider }); // add first
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Void call() {
+            if (complete.compareAndSet(false, true) && delegates != null) {
+                for (Object[] r : delegates) {
+                    try {
+                        ((Callable<Void>) r[0]).call();
                     } catch (Exception e) {
                         LOGGER.error("PreDestroy call failed for " + r, e);
                     }
-                 }
-                 delegates.clear();
-                 clear();
-             }
-             return null;
-         }
+                }
+                delegates.clear();
+                clear();
+            }
+            return null;
+        }
 
         @Override
         public int compareTo(ScopeCleanupAction o) {
             return Long.compare(ordinal, o.ordinal);
-        }         
-     }    
+        }
+    }
 }

--- a/governator-core/src/test/java/com/netflix/governator/PreDestroyTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/PreDestroyTest.java
@@ -32,7 +32,7 @@ public class PreDestroyTest {
         }
         
         @PreDestroy
-        public void shutdown() {
+        protected void shutdown() {
             shutdown = true;
         }
         

--- a/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
@@ -50,7 +50,7 @@ public class ConfigurationLifecycleFeature implements LifecycleFeature {
     @Override
     public List<LifecycleAction> getActionsForType(final Class<?> type) {
         final LifecycleMethods methods = new LifecycleMethods(type);
-        if (!methods.fieldsFor(Configuration.class).isEmpty()) {
+        if (methods.fieldsFor(Configuration.class).length > 0) {
             return Arrays.<LifecycleAction>asList(new LifecycleAction() {
                 @Override
                 public void call(Object obj) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/DelegatingLifecycleInjectorBuilder.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/DelegatingLifecycleInjectorBuilder.java
@@ -123,6 +123,12 @@ public class DelegatingLifecycleInjectorBuilder implements LifecycleInjectorBuil
     }
 
     @Override
+    public LifecycleInjectorBuilder requiringExplicitBindings() {
+        this.delegate = delegate.requiringExplicitBindings();
+        return this;
+    }
+
+    @Override
     public LifecycleInjectorBuilder usingBasePackages(String... basePackages) {
         this.delegate = delegate.usingBasePackages(basePackages);
         return this;

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalBootstrapModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalBootstrapModule.java
@@ -28,6 +28,7 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
 import com.netflix.governator.configuration.ConfigurationDocumentation;
+import com.netflix.governator.configuration.ConfigurationMapper;
 import com.netflix.governator.configuration.ConfigurationProvider;
 import com.netflix.governator.guice.lazy.FineGrainedLazySingleton;
 import com.netflix.governator.guice.lazy.FineGrainedLazySingletonScope;
@@ -36,6 +37,7 @@ import com.netflix.governator.guice.lazy.LazySingletonScope;
 import com.netflix.governator.lifecycle.ClasspathScanner;
 import com.netflix.governator.lifecycle.LifecycleConfigurationProviders;
 import com.netflix.governator.lifecycle.LifecycleManager;
+import com.netflix.governator.lifecycle.LifecycleManagerArguments;
 
 class InternalBootstrapModule extends AbstractModule
 {
@@ -94,6 +96,8 @@ class InternalBootstrapModule extends AbstractModule
             }
         }
 
+        bind(com.netflix.governator.LifecycleManager.class).in(Scopes.SINGLETON);
+        binder().bind(LifecycleManagerArguments.class).in(Scopes.SINGLETON);
         binder().bind(LifecycleManager.class).asEagerSingleton();
         binder().bind(LifecycleConfigurationProviders.class).toProvider(LifecycleConfigurationProvidersProvider.class).asEagerSingleton();
         

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalLifecycleModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalLifecycleModule.java
@@ -1,17 +1,14 @@
 /*
  * Copyright 2012 Netflix, Inc.
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package com.netflix.governator.guice;
@@ -34,20 +31,22 @@ import com.google.inject.spi.ProvisionListener;
 import com.netflix.governator.lifecycle.LifecycleListener;
 import com.netflix.governator.lifecycle.LifecycleManager;
 import com.netflix.governator.lifecycle.LifecycleMethods;
+import static com.netflix.governator.internal.BinaryConstant.*;
 
 class InternalLifecycleModule extends AbstractModule implements ProvisionListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(InternalLifecycleModule.class);
     private final LoadingCache<Class<?>, LifecycleMethods> lifecycleMethods = CacheBuilder
-        .newBuilder()
-        .initialCapacity(1<<13)
-        .concurrencyLevel(1<<8)
-        .softValues()
-        .build(new CacheLoader<Class<?>, LifecycleMethods>(){
-            @Override
-            public LifecycleMethods load(Class<?> key) throws Exception {
-                return new LifecycleMethods(key);
-            }});
-    
+            .newBuilder()
+            .initialCapacity(I13_8192) // number of classes with metadata
+            .concurrencyLevel(I8_256)  // number of concurrent metadata producers (no locks for read)
+            .softValues()
+            .build(new CacheLoader<Class<?>, LifecycleMethods>() {
+                @Override
+                public LifecycleMethods load(Class<?> key) throws Exception {
+                    return new LifecycleMethods(key);
+                }
+            });
+
     private final AtomicReference<LifecycleManager> lifecycleManager;
 
     InternalLifecycleModule(AtomicReference<LifecycleManager> lifecycleManager) {
@@ -58,10 +57,9 @@ class InternalLifecycleModule extends AbstractModule implements ProvisionListene
     public void configure() {
         bindListener(
                 Matchers.any(),
-               this
-            ); 
+                this);
     }
-    
+
     @Override
     public <T> void onProvision(ProvisionInvocation<T> provision) {
         T instance = provision.provision();
@@ -69,31 +67,29 @@ class InternalLifecycleModule extends AbstractModule implements ProvisionListene
             Binding<T> binding = provision.getBinding();
 
             LifecycleManager manager = lifecycleManager.get();
-            if ( manager != null ) {
+            if (manager != null) {
                 Key<T> bindingKey = binding.getKey();
                 LOGGER.trace("provisioning instance of {}", bindingKey);
                 TypeLiteral<T> bindingType = bindingKey.getTypeLiteral();
-                for ( LifecycleListener listener : manager.getListeners() ) {
+                for (LifecycleListener listener : manager.getListeners()) {
                     listener.objectInjected(bindingType, instance);
                 }
-    
+
                 try {
                     LifecycleMethods methods = lifecycleMethods.get(instance.getClass());
-                    if ( methods.hasLifecycleAnnotations() ) {
-                            manager.add(instance, binding, methods);
+                    if (methods.hasLifecycleAnnotations()) {
+                        manager.add(instance, binding, methods);
                     }
-                }
-                catch ( ExecutionException e ) {
+                } catch (ExecutionException e) {
                     // caching problem
                     throw new RuntimeException(e);
-                }
-                catch ( Throwable e ) {
+                } catch (Throwable e) {
                     // unknown problem will abort injector start up
                     throw new Error(e);
                 }
-                
+
             }
         }
-    }    
+    }
 
 }

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalLifecycleModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalLifecycleModule.java
@@ -81,7 +81,7 @@ class InternalLifecycleModule extends AbstractModule implements ProvisionListene
                 try {
                     manager.add(obj, binding, methods);
                 }
-                catch ( Exception e ) {
+                catch ( Throwable e ) {
                     throw new Error(e);
                 }
             }

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
@@ -199,7 +199,7 @@ public class LifecycleInjector
                     	}
                     	// This is a bootstrap module
                     	if (!bootstrap.bootstrap().equals(Bootstrap.NullBootstrapModule.class)) {
-                    		Preconditions.checkState(added==false, "{} already added as a LifecycleInjectorBuilderSuite", bootstrap.annotationType().getName());
+                    		Preconditions.checkState(added==false, "%s already added as a LifecycleInjectorBuilderSuite", bootstrap.annotationType().getName());
                     		added = true;
                             LOG.info("Adding BootstrapModule {}", bootstrap.bootstrap());
 	                        bootstrapModules
@@ -211,7 +211,7 @@ public class LifecycleInjector
                     	}
                     	// This is a plain guice module
                     	if (!bootstrap.module().equals(Bootstrap.NullModule.class)) {
-                    		Preconditions.checkState(added==false, "{} already added as a BootstrapModule", bootstrap.annotationType().getName());
+                    		Preconditions.checkState(added==false, "%s already added as a BootstrapModule", bootstrap.annotationType().getName());
                     		added = true;
                             LOG.info("Adding Module {}", bootstrap.bootstrap());
 	                        builder.withAdditionalModuleClasses(bootstrap.module());

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
@@ -53,6 +53,8 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import com.netflix.governator.LifecycleListenerModule;
 import com.netflix.governator.annotations.AutoBindSingleton;
+import com.netflix.governator.configuration.ConfigurationMapper;
+import com.netflix.governator.configuration.ConfigurationProvider;
 import com.netflix.governator.guice.annotations.Bootstrap;
 import com.netflix.governator.guice.lazy.FineGrainedLazySingleton;
 import com.netflix.governator.guice.lazy.FineGrainedLazySingletonScope;
@@ -87,6 +89,7 @@ public class LifecycleInjector
     private final List<Module> modules;
     private final Collection<Class<?>> ignoreClasses;
     private final boolean ignoreAllClasses;
+    private boolean requireExplicitBindings;
     private final LifecycleManager lifecycleManager;
     private final Injector injector;
     private final Stage stage;
@@ -379,7 +382,15 @@ public class LifecycleInjector
         
         //Add the LifecycleListener module
         localModules.add(new LifecycleListenerModule());
-        
+        localModules.add(new AbstractModule() {
+            @Override
+            public void configure() {
+                if (requireExplicitBindings) {
+                    binder().requireExplicitBindings();
+                }                              
+            }
+        });
+       
         if ( additionalModules != null )
         {
             localModules.addAll(additionalModules);
@@ -420,6 +431,7 @@ public class LifecycleInjector
                 builder.getPostInjectorActions(),
                 builder.getModuleTransformers(),
                 builder.isDisableAutoBinding());
+        this.requireExplicitBindings = builder.isRequireExplicitBindings();
         
         injector = Guice.createInjector
         (
@@ -472,7 +484,7 @@ public class LifecycleInjector
                     }
                     Provider provider = binding.getValue().getProvider();
                     bind(binding.getKey()).toProvider(provider);
-                }
+                }                
             }
         };
 

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjector.java
@@ -196,7 +196,7 @@ public class LifecycleInjector
                     	}
                     	// This is a bootstrap module
                     	if (!bootstrap.bootstrap().equals(Bootstrap.NullBootstrapModule.class)) {
-                    		Preconditions.checkState(added==false, bootstrap.annotationType().getName() + " already added as a LifecycleInjectorBuilderSuite");
+                    		Preconditions.checkState(added==false, "{} already added as a LifecycleInjectorBuilderSuite", bootstrap.annotationType().getName());
                     		added = true;
                             LOG.info("Adding BootstrapModule {}", bootstrap.bootstrap());
 	                        bootstrapModules
@@ -208,7 +208,7 @@ public class LifecycleInjector
                     	}
                     	// This is a plain guice module
                     	if (!bootstrap.module().equals(Bootstrap.NullModule.class)) {
-                    		Preconditions.checkState(added==false, bootstrap.annotationType().getName() + " already added as a BootstrapModule");
+                    		Preconditions.checkState(added==false, "{} already added as a BootstrapModule", bootstrap.annotationType().getName());
                     		added = true;
                             LOG.info("Adding Module {}", bootstrap.bootstrap());
 	                        builder.withAdditionalModuleClasses(bootstrap.module());

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilder.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilder.java
@@ -233,6 +233,14 @@ public interface LifecycleInjectorBuilder
      * @return this
      */
     public LifecycleInjectorBuilder ignoringAllAutoBindClasses();
+    
+    
+    /**
+     * Do not use implicit bindings
+     *
+     * @return this
+     */
+    public LifecycleInjectorBuilder requiringExplicitBindings();
 
     /**
      * Specify the base packages for CLASSPATH scanning. Packages are recursively scanned

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilderImpl.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/LifecycleInjectorBuilderImpl.java
@@ -35,6 +35,7 @@ class LifecycleInjectorBuilderImpl implements LifecycleInjectorBuilder
     private Collection<Class<?>> ignoreClasses = Lists.newArrayList();
     private Collection<String> basePackages = Lists.newArrayList();
     private boolean disableAutoBinding = false;
+    private boolean requireExplicitBindings = false;
     private List<BootstrapModule> bootstrapModules = Lists.newArrayList();
     private ClasspathScanner scanner = null;
     private Stage stage = Stage.PRODUCTION;
@@ -203,6 +204,13 @@ class LifecycleInjectorBuilderImpl implements LifecycleInjectorBuilder
     }
 
     @Override
+    public LifecycleInjectorBuilder requiringExplicitBindings()
+    {
+        this.requireExplicitBindings = true;
+        return this;
+    }
+
+    @Override
     public LifecycleInjectorBuilder usingBasePackages(String... basePackages)
     {
         return usingBasePackages(Arrays.asList(basePackages));
@@ -357,6 +365,10 @@ class LifecycleInjectorBuilderImpl implements LifecycleInjectorBuilder
 
     boolean isDisableAutoBinding() {
         return this.disableAutoBinding;
+    }
+
+    boolean isRequireExplicitBindings() {
+        return this.requireExplicitBindings;
     }
 
 }

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
@@ -7,17 +7,12 @@ import com.netflix.governator.configuration.ConfigurationDocumentation;
 import com.netflix.governator.configuration.ConfigurationMapper;
 import com.netflix.governator.configuration.ConfigurationProvider;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
 public class DefaultConfigurationMapper implements ConfigurationMapper {
-    
     @Override
     public void mapConfiguration(
             ConfigurationProvider configurationProvider, 
@@ -37,12 +32,11 @@ public class DefaultConfigurationMapper implements ConfigurationMapper {
             final Map<String, String> overrides;
             Collection<Field> configurationVariableFields = methods.fieldsFor(ConfigurationVariable.class);
             if (!configurationVariableFields.isEmpty()) {
-                Lookup lookup = MethodHandles.lookup();
                 overrides = Maps.newHashMap();
                 for ( Field variableField : configurationVariableFields) {
                     ConfigurationVariable annot = variableField.getAnnotation(ConfigurationVariable.class);
                     if (annot != null) {
-                        overrides.put(annot.name(), invoke(variableField, obj).toString());
+                        overrides.put(annot.name(), methods.fieldGet(variableField, obj).toString());
                     }
                 }
             }
@@ -63,13 +57,5 @@ public class DefaultConfigurationMapper implements ConfigurationMapper {
         }
     }
 
-    private Object invoke(Field variableField, Object obj) throws InvocationTargetException, IllegalAccessException {
-        MethodHandle handler = MethodHandles.lookup().unreflectGetter(variableField);
-        try {
-            return handler.invoke(obj);
-        } catch (Throwable e) {
-            throw new InvocationTargetException(e);
-        }
-    }
 
 }

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
@@ -1,5 +1,9 @@
 package com.netflix.governator.lifecycle;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+
 import com.google.common.collect.Maps;
 import com.netflix.governator.annotations.Configuration;
 import com.netflix.governator.annotations.ConfigurationVariable;
@@ -7,33 +11,28 @@ import com.netflix.governator.configuration.ConfigurationDocumentation;
 import com.netflix.governator.configuration.ConfigurationMapper;
 import com.netflix.governator.configuration.ConfigurationProvider;
 
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-
 public class DefaultConfigurationMapper implements ConfigurationMapper {
     @Override
     public void mapConfiguration(
-            ConfigurationProvider configurationProvider, 
-            ConfigurationDocumentation configurationDocumentation, 
-            Object obj, 
+            ConfigurationProvider configurationProvider,
+            ConfigurationDocumentation configurationDocumentation,
+            Object obj,
             LifecycleMethods methods) throws Exception {
-        
+
         /**
          * Map a configuration to any field with @Configuration annotation
          */
-        Collection<Field> configurationFields = methods.fieldsFor(Configuration.class);
-        if (!configurationFields.isEmpty()) {
+        Field[] configurationFields = methods.fieldsFor(Configuration.class);
+        if (configurationFields.length > 0) {
             /**
-             * Any field annotated with @ConfigurationVariable will be available for
-             * replacement when generating property names
+             * Any field annotated with @ConfigurationVariable will be available for replacement when generating
+             * property names
              */
             final Map<String, String> overrides;
-            Collection<Field> configurationVariableFields = methods.fieldsFor(ConfigurationVariable.class);
-            if (!configurationVariableFields.isEmpty()) {
+            Field[] configurationVariableFields = methods.fieldsFor(ConfigurationVariable.class);
+            if (configurationVariableFields.length > 0) {
                 overrides = Maps.newHashMap();
-                for ( Field variableField : configurationVariableFields) {
+                for (Field variableField : configurationVariableFields) {
                     ConfigurationVariable annot = variableField.getAnnotation(ConfigurationVariable.class);
                     if (annot != null) {
                         overrides.put(annot.name(), methods.fieldGet(variableField, obj).toString());
@@ -43,19 +42,18 @@ public class DefaultConfigurationMapper implements ConfigurationMapper {
             else {
                 overrides = Collections.emptyMap();
             }
-            
-            ConfigurationProcessor configurationProcessor = new ConfigurationProcessor(configurationProvider, configurationDocumentation);
-            for ( Field configurationField : configurationFields )
-            {
+
+            ConfigurationProcessor configurationProcessor = new ConfigurationProcessor(configurationProvider,
+                    configurationDocumentation);
+            for (Field configurationField : configurationFields) {
                 try {
                     configurationProcessor.assignConfiguration(obj, configurationField, overrides);
-                }
-                catch (Exception e) {
-                    throw new Exception(String.format("Failed to bind property '%s' for instance of '%s'", configurationField.getName(), obj.getClass().getCanonicalName()), e);
+                } catch (Exception e) {
+                    throw new Exception(String.format("Failed to bind property '%s' for instance of '%s'",
+                            configurationField.getName(), obj.getClass().getCanonicalName()), e);
                 }
             }
         }
     }
-
 
 }

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
@@ -17,7 +17,6 @@
 package com.netflix.governator.lifecycle;
 
 import java.io.Closeable;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
@@ -32,7 +31,6 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Path;
 import javax.validation.Validation;
 import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import javax.validation.groups.Default;
 
 import org.slf4j.Logger;
@@ -77,7 +75,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     private final ConfigurationMapper configurationMapper;
     private final ResourceMapper resourceMapper;
     final Collection<LifecycleListener> listeners;
-    private final Validator factory;
+    private final Validator validator;
     private final PreDestroyMonitor preDestroyMonitor;
     private com.netflix.governator.LifecycleManager newLifecycleManager;
 
@@ -104,7 +102,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
         newLifecycleManager = arguments.getLifecycleManager();
         listeners = ImmutableSet.copyOf(arguments.getLifecycleListeners());
         resourceMapper = new ResourceMapper(injector, ImmutableSet.copyOf(arguments.getResourceLocators()));
-        factory = Validation.buildDefaultValidatorFactory().getValidator();
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
         configurationDocumentation = arguments.getConfigurationDocumentation();
         configurationProvider = arguments.getConfigurationProvider();
     }
@@ -281,7 +279,6 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     public void validate() throws ValidationException
     {
         ValidationException exception = null;
-        Validator validator = factory;
         for ( Object managedInstance : objectStates.keySet() )
         {
             if (managedInstance != null) {
@@ -303,14 +300,13 @@ public class LifecycleManager implements Closeable, PostInjectorAction
      */
     public void validate(Object obj) throws ValidationException
     {
-        Validator validator = factory;
         ValidationException exception = internalValidateObject(null, obj, validator);
         if ( exception != null )
         {
             throw exception;
         }
     }
-    
+        
     class LifecycleStateWrapper {
         volatile LifecycleState state;
 

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
@@ -16,14 +16,10 @@
 
 package com.netflix.governator.lifecycle;
 
-import java.beans.Introspector;
 import java.io.Closeable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,9 +28,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
-import javax.annotation.Resources;
-import javax.naming.NamingException;
 import javax.validation.ConstraintViolation;
 import javax.validation.Path;
 import javax.validation.Validation;
@@ -82,10 +75,9 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     private final ConfigurationDocumentation configurationDocumentation;
     private final ConfigurationProvider configurationProvider;
     private final ConfigurationMapper configurationMapper;
+    private final ResourceMapper resourceMapper;
     final Collection<LifecycleListener> listeners;
-    private final Collection<ResourceLocator> resourceLocators;
-    private final ValidatorFactory factory;
-    private Injector injector;
+    private final Validator factory;
     private final PreDestroyMonitor preDestroyMonitor;
     private com.netflix.governator.LifecycleManager newLifecycleManager;
 
@@ -102,7 +94,6 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     @Inject
     public LifecycleManager(LifecycleManagerArguments arguments, Injector injector)
     {
-        this.injector = injector;
         if (injector != null) {
             preDestroyMonitor =  new PreDestroyMonitor(injector.getScopeBindings());
         }
@@ -112,8 +103,8 @@ public class LifecycleManager implements Closeable, PostInjectorAction
         configurationMapper = arguments.getConfigurationMapper();
         newLifecycleManager = arguments.getLifecycleManager();
         listeners = ImmutableSet.copyOf(arguments.getLifecycleListeners());
-        resourceLocators = ImmutableSet.copyOf(arguments.getResourceLocators());
-        factory = Validation.buildDefaultValidatorFactory();
+        resourceMapper = new ResourceMapper(injector, ImmutableSet.copyOf(arguments.getResourceLocators()));
+        factory = Validation.buildDefaultValidatorFactory().getValidator();
         configurationDocumentation = arguments.getConfigurationDocumentation();
         configurationProvider = arguments.getConfigurationProvider();
     }
@@ -166,14 +157,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     @Deprecated
     public void add(Object obj, LifecycleMethods methods) throws Exception
     {
-        Preconditions.checkState(state.get() != State.CLOSED, "LifecycleManager is closed");
-
-        startInstance(obj, null, methods);
-
-        if ( hasStarted() )
-        {
-            initializeObjectPostStart(obj);
-        }
+        add(obj, null, methods);
     }
     
     /**
@@ -186,14 +170,17 @@ public class LifecycleManager implements Closeable, PostInjectorAction
      */
     public <T> void add(T obj, Binding<T> binding, LifecycleMethods methods) throws Exception
     {
-        Preconditions.checkState(state.get() != State.CLOSED, "LifecycleManager is closed");
-
-        startInstance(obj, binding, methods);
-
-        if ( hasStarted() )
-        {
-            initializeObjectPostStart(obj);
-        }
+       State managerState = state.get();
+       if (managerState != State.CLOSED) {     
+           startInstance(obj, binding, methods);
+           if ( managerState == State.STARTED )
+           {
+               initializeObjectPostStart(obj);
+           }
+       }
+       else {
+           throw new IllegalStateException("LifecycleManager is closed");
+       }
     }
     
 
@@ -220,7 +207,9 @@ public class LifecycleManager implements Closeable, PostInjectorAction
         {
             return hasStarted() ? LifecycleState.ACTIVE : LifecycleState.LATENT;
         }
-        return lifecycleState.get();
+        else {
+            return lifecycleState.get();
+        }
     }
 
     /**
@@ -292,7 +281,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
     public void validate() throws ValidationException
     {
         ValidationException exception = null;
-        Validator validator = factory.getValidator();
+        Validator validator = factory;
         for ( Object managedInstance : objectStates.keySet() )
         {
             if (managedInstance != null) {
@@ -314,7 +303,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
      */
     public void validate(Object obj) throws ValidationException
     {
-        Validator validator = factory.getValidator();
+        Validator validator = factory;
         ValidationException exception = internalValidateObject(null, obj, validator);
         if ( exception != null )
         {
@@ -388,7 +377,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
         configurationMapper.mapConfiguration(configurationProvider, configurationDocumentation, obj, methods);
 
         lifecycleState.set(obj, LifecycleState.SETTING_RESOURCES);
-        setResources(obj, methods);
+        resourceMapper.map(obj, methods);
 
         lifecycleState.set(obj, LifecycleState.POST_CONSTRUCTING);
         methods.methodInvoke(PostConstruct.class, obj);
@@ -425,201 +414,6 @@ public class LifecycleManager implements Closeable, PostInjectorAction
             }
         }
 
-    }
-
-    private void setResources(Object obj, LifecycleMethods methods) throws Exception
-    {
-        if (methods.hasResources()) {        
-            Collection<Field> fieldResources = methods.fieldsFor(Resources.class);
-            if (!fieldResources.isEmpty()) {
-                for ( Field field : fieldResources )
-                {
-                    Resources resources = field.getAnnotation(Resources.class);
-                    for ( Resource resource : resources.value() )
-                    {
-                        setFieldResource(obj, field, resource);
-                    }
-                }
-            }
-    
-            Collection<Field> fieldResource = methods.fieldsFor(Resource.class);
-            if (!fieldResource.isEmpty()) {
-                for ( Field field : fieldResource )
-                {
-                    Resource resource = field.getAnnotation(Resource.class);
-                    setFieldResource(obj, field, resource);
-                }
-            }
-    
-            Collection<Method> methodResources = methods.methodsFor(Resources.class);
-            if (!methodResources.isEmpty()) {
-                for ( Method method : methodResources )
-                {
-                    Resources resources = method.getAnnotation(Resources.class);
-                    for ( Resource resource : resources.value() )
-                    {
-                        setMethodResource(obj, method, resource);
-                    }
-                }
-            }
-    
-            Collection<Method> methodResource = methods.methodsFor(Resource.class);
-            if (!methodResource.isEmpty()) {
-                for ( Method method : methodResource )
-                {
-                    Resource resource = method.getAnnotation(Resource.class);
-                    setMethodResource(obj, method, resource);
-                }
-            }
-    
-            Collection<Resources> classResources = methods.classAnnotationsFor(Resources.class);
-            if (!classResources.isEmpty()) {
-                for ( Resources resources : classResources )
-                {
-                    for ( Resource resource : resources.value() )
-                    {
-                        loadClassResource(resource);
-                    }
-                }
-            }
-    
-            Collection<Resource> classResource = methods.classAnnotationsFor(Resource.class);            
-            if (!classResource.isEmpty()) {
-                for ( Resource resource : classResource )
-                {
-                    loadClassResource(resource);
-                }
-            }
-        }
-    }
-
-    private void loadClassResource(Resource resource) throws Exception
-    {
-        if ( (resource.name().isEmpty()) || (resource.type() == Object.class) )
-        {
-            throw new Exception("Class resources must have both name() and type(): " + resource);
-        }
-        findResource(resource);
-    }
-
-    private void setMethodResource(Object obj, Method method, Resource resource) throws Exception
-    {
-        if ( (method.getParameterTypes().length != 1) || (method.getReturnType() != Void.TYPE) )
-        {
-            throw new Exception(String.format("%s.%s() is not a proper JavaBean setter.", obj.getClass().getName(), method.getName()));
-        }
-
-        String beanName = method.getName();
-        if ( beanName.toLowerCase().startsWith("set") )
-        {
-            beanName = beanName.substring("set".length());
-        }
-        beanName = Introspector.decapitalize(beanName);
-
-        String siteName = obj.getClass().getName() + "/" + beanName;
-        resource = adjustResource(resource, method.getParameterTypes()[0], siteName);
-        Object resourceObj = findResource(resource);
-        method.setAccessible(true);
-        method.invoke(obj, resourceObj);
-    }
-
-    private void setFieldResource(Object obj, Field field, Resource resource) throws Exception
-    {
-        String siteName = obj.getClass().getName() + "/" + field.getName();
-        Object resourceObj = findResource(adjustResource(resource, field.getType(), siteName));
-        field.setAccessible(true);
-        field.set(obj, resourceObj);
-    }
-
-    private Resource adjustResource(final Resource resource, final Class<?> siteType, final String siteName)
-    {
-        return new Resource()
-        {
-            @Override
-            public String name()
-            {
-                return (resource.name().length() == 0) ? siteName : resource.name();
-            }
-
-            /**
-             * Method needed for eventual java7 compatibility
-             */
-            public String lookup()
-            {
-                return name();
-            }
-
-            @Override
-            public Class<?> type()
-            {
-                return (resource.type() == Object.class) ? siteType : resource.type();
-            }
-
-            @Override
-            public AuthenticationType authenticationType()
-            {
-                return resource.authenticationType();
-            }
-
-            @Override
-            public boolean shareable()
-            {
-                return resource.shareable();
-            }
-
-            @Override
-            public String mappedName()
-            {
-                return resource.mappedName();
-            }
-
-            @Override
-            public String description()
-            {
-                return resource.description();
-            }
-
-            @Override
-            public Class<? extends Annotation> annotationType()
-            {
-                return resource.annotationType();
-            }
-        };
-    }
-
-    private Object findResource(Resource resource) throws Exception
-    {
-        if ( !resourceLocators.isEmpty() )
-        {
-            final Iterator<ResourceLocator> iterator = resourceLocators.iterator();
-            ResourceLocator locator = iterator.next();
-            ResourceLocator nextInChain = new ResourceLocator()
-            {
-                @Override
-                public Object locate(Resource resource, ResourceLocator nextInChain) throws Exception
-                {
-                    if ( iterator.hasNext() )
-                    {
-                        return iterator.next().locate(resource, this);
-                    }
-                    return defaultFindResource(resource);
-                }
-            };
-            return locator.locate(resource, nextInChain);
-        }
-        return defaultFindResource(resource);
-    }
-
-    private Object defaultFindResource(Resource resource) throws Exception
-    {
-        if ( injector == null )
-        {
-            throw new NamingException("Could not find resource: " + resource);
-        }
-
-        //noinspection unchecked     
-        log.debug("defaultFindResource using injector {}", System.identityHashCode(injector));
-        return injector.getInstance(resource.type());
     }
 
     private void stopInstances() throws Exception
@@ -659,7 +453,7 @@ public class LifecycleManager implements Closeable, PostInjectorAction
 
     @Override
     public void call(Injector injector) {
-        this.injector = injector;
-        preDestroyMonitor.addScopeBindings(injector.getScopeBindings());
-    }   
+        this.resourceMapper.setInjector(injector);
+        this.preDestroyMonitor.addScopeBindings(injector.getScopeBindings());
+    }
 }

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -123,7 +124,7 @@ public class LifecycleMethods {
             for (Class<? extends Annotation> annotationClass : classAnnotations) {
                 if (clazz.isAnnotationPresent(annotationClass)) {
                     classMap.put(annotationClass, clazz.getAnnotation(annotationClass));
-                }
+                }                
             }
 
             for (Field field : getDeclaredFields(clazz)) {
@@ -243,16 +244,20 @@ public class LifecycleMethods {
         this.hasValidations = builder.hasValidations;
         methodMap = new HashMap<>();
         for (Map.Entry<Class<? extends Annotation>, Collection<Method>> entry : builder.methodMap.asMap().entrySet()) {
-            methodMap.put(entry.getKey(), entry.getValue().toArray(new Method[0]));
+            methodMap.put(entry.getKey(), entry.getValue().toArray(EMPTY_METHODS));
         }
         fieldMap = new HashMap<>();
         for (Map.Entry<Class<? extends Annotation>, Collection<Field>> entry : builder.fieldMap.asMap().entrySet()) {
-            fieldMap.put(entry.getKey(), entry.getValue().toArray(new Field[0]));
+            fieldMap.put(entry.getKey(), entry.getValue().toArray(EMPTY_FIELDS));
         }
         classMap = new HashMap<>();
-        for (Map.Entry<Class<? extends Annotation>, Collection<Annotation>> entry : builder.classMap.asMap().entrySet()) {
-            
-            classMap.put(entry.getKey(), entry.getValue().toArray((Annotation[])Array.newInstance(entry.getKey().getClass(), 0)));
+        for (Class<? extends Annotation> annotationClass : LifecycleMethodsBuilder.classAnnotations) {            
+            Annotation[] annotationsArray = (Annotation[])Array.newInstance(annotationClass, 0);
+            Collection<Annotation> annotations = builder.classMap.get(annotationClass);
+            if (annotations != null) {
+                annotationsArray = annotations.toArray(annotationsArray);
+            }            
+            classMap.put(annotationClass, annotationsArray);
         }
 
     }
@@ -277,7 +282,8 @@ public class LifecycleMethods {
 
     @SuppressWarnings("unchecked")
     public <T extends Annotation> T[] classAnnotationsFor(Class<T> annotation) {
-        return (T[])classMap.get(annotation);
+        Annotation[] annotations = classMap.get(annotation);
+        return (annotations != null) ? (T[])annotations : (T[])Array.newInstance(annotation, 0);
     }
 
     

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
@@ -16,18 +16,25 @@
 
 package com.netflix.governator.lifecycle;
 
+import static com.netflix.governator.internal.BinaryConstant.*;
+import static com.netflix.governator.internal.BinaryConstant.I3_8;
+import static com.netflix.governator.internal.BinaryConstant.I4_16;
+import static com.netflix.governator.internal.BinaryConstant.I5_32;
+import static com.netflix.governator.internal.BinaryConstant.I9_512;
+
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -50,185 +57,229 @@ import com.netflix.governator.annotations.WarmUp;
  * Used internally to hold the methods important to the LifecycleManager
  */
 public class LifecycleMethods {
-    private static final Field[] EMPTY_FIELDS = new Field[] {};
-    private static final Method[] EMPTY_METHODS = new Method[] {};
+    private static final Field[] EMPTY_FIELDS = new Field[0];
+    private static final Method[] EMPTY_METHODS = new Method[0];
     private static final Lookup METHOD_HANDLE_LOOKUP = MethodHandles.lookup();
-    private static final ConcurrentMap<Object, MethodHandle> methodHandlesMap = new ConcurrentHashMap<>(1<<13, 0.75f);
-
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Multimap<Class<? extends Annotation>, Field> fieldMap = ArrayListMultimap.create(1<<13, 1<<3);
-    private final Multimap<Class<? extends Annotation>, Method> methodMap = ArrayListMultimap.create(1<<13, 1<<3);
-    private final Multimap<Class<? extends Annotation>, Annotation> classMap = ArrayListMultimap.create(1<<13, 1<<3);
+    
+    private static final Logger log = LoggerFactory.getLogger(LifecycleMethods.class);
 
     private boolean hasValidations = false;
     private final boolean hasResources;
+    final static Map<Method, MethodHandle> methodHandlesMap = new ConcurrentHashMap<>(I15_32768);
+    final static Map<Field, MethodHandle[]> fieldHandlesMap = new ConcurrentHashMap<>(I15_32768);
 
-    private static final Collection<Class<? extends Annotation>> fieldAnnotations;
-    private static final Collection<Class<? extends Annotation>> methodAnnotations;
-    private static final Collection<Class<? extends Annotation>> classAnnotations;
+    
+    static class LifecycleMethodsBuilder {
+        private static final Logger log = LoggerFactory.getLogger(LifecycleMethodsBuilder.class);
+        private static final Collection<Class<? extends Annotation>> fieldAnnotations;
+        private static final Collection<Class<? extends Annotation>> methodAnnotations;
+        private static final Collection<Class<? extends Annotation>> classAnnotations;
+        static {
+            ImmutableSet.Builder<Class<? extends Annotation>> methodAnnotationsBuilder = ImmutableSet.builder();
+            methodAnnotationsBuilder.add(PreConfiguration.class);
+            methodAnnotationsBuilder.add(PostConstruct.class);
+            methodAnnotationsBuilder.add(PreDestroy.class);
+            methodAnnotationsBuilder.add(Resource.class);
+            methodAnnotationsBuilder.add(Resources.class);
+            methodAnnotationsBuilder.add(WarmUp.class);
+            methodAnnotations = methodAnnotationsBuilder.build();
 
-    static {
-        ImmutableSet.Builder<Class<? extends Annotation>> methodAnnotationsBuilder = ImmutableSet.builder();
-        methodAnnotationsBuilder.add(PreConfiguration.class);
-        methodAnnotationsBuilder.add(PostConstruct.class);
-        methodAnnotationsBuilder.add(PreDestroy.class);
-        methodAnnotationsBuilder.add(Resource.class);
-        methodAnnotationsBuilder.add(Resources.class);
-        methodAnnotationsBuilder.add(WarmUp.class);
-        methodAnnotations = methodAnnotationsBuilder.build();
+            ImmutableSet.Builder<Class<? extends Annotation>> fieldAnnotationsBuilder = ImmutableSet.builder();
+            fieldAnnotationsBuilder.add(Configuration.class);
+            fieldAnnotationsBuilder.add(Resource.class);
+            fieldAnnotationsBuilder.add(Resources.class);
+            fieldAnnotationsBuilder.add(ConfigurationVariable.class);
+            fieldAnnotations = fieldAnnotationsBuilder.build();
 
-        ImmutableSet.Builder<Class<? extends Annotation>> fieldAnnotationsBuilder = ImmutableSet.builder();
-        fieldAnnotationsBuilder.add(Configuration.class);
-        fieldAnnotationsBuilder.add(Resource.class);
-        fieldAnnotationsBuilder.add(Resources.class);
-        fieldAnnotationsBuilder.add(ConfigurationVariable.class);
-        fieldAnnotations = fieldAnnotationsBuilder.build();
+            ImmutableSet.Builder<Class<? extends Annotation>> classAnnotationsBuilder = ImmutableSet.builder();
+            classAnnotationsBuilder.add(Resource.class);
+            classAnnotationsBuilder.add(Resources.class);
+            classAnnotations = classAnnotationsBuilder.build();
+        }
 
-        ImmutableSet.Builder<Class<? extends Annotation>> classAnnotationsBuilder = ImmutableSet.builder();
-        classAnnotationsBuilder.add(Resource.class);
-        classAnnotationsBuilder.add(Resources.class);
-        classAnnotations = classAnnotationsBuilder.build();
+        private boolean hasValidations = false;
+        private boolean hasResources;
+        private final Multimap<Class<? extends Annotation>, Field> fieldMap = ArrayListMultimap.create(I3_8, I5_32);
+        private final Multimap<Class<? extends Annotation>, Method> methodMap = ArrayListMultimap.create(I4_16, I5_32);
+        private final Multimap<Class<? extends Annotation>, Annotation> classMap = ArrayListMultimap.create(I2_4, I3_8);
+        
+        public LifecycleMethodsBuilder( Class<?> clazz, Multimap<Class<? extends Annotation>, String> usedNames) {
+            addLifeCycleMethods(clazz, ArrayListMultimap.<Class<? extends Annotation>, String> create());
+            this.hasResources = fieldMap.containsKey(Resource.class) || 
+                    fieldMap.containsKey(Resources.class) ||
+                    methodMap.containsKey(Resource.class) ||
+                    methodMap.containsKey(Resources.class) ||
+                    classMap.containsKey(Resource.class) ||
+                    classMap.containsKey(Resources.class);
+            this.hasValidations = this.hasValidations ||  !methodMap.isEmpty() || !fieldMap.isEmpty();            
+        }
+
+        
+        void addLifeCycleMethods(Class<?> clazz, Multimap<Class<? extends Annotation>, String> usedNames) {
+            if (clazz == null) {
+                return;
+            }
+
+            for (Class<? extends Annotation> annotationClass : classAnnotations) {
+                if (clazz.isAnnotationPresent(annotationClass)) {
+                    classMap.put(annotationClass, clazz.getAnnotation(annotationClass));
+                }
+            }
+
+            for (Field field : getDeclaredFields(clazz)) {
+                if (field.isSynthetic()) {
+                    continue;
+                }
+
+                if (!hasValidations) {
+                    checkForValidations(field);
+                }
+
+                for (Class<? extends Annotation> annotationClass : fieldAnnotations) {
+                    processField(field, annotationClass, usedNames);
+                }
+            }
+
+            for (Method method : getDeclaredMethods(clazz)) {
+                if (method.isSynthetic() || method.isBridge()) {
+                    continue;
+                }
+
+                for (Class<? extends Annotation> annotationClass : methodAnnotations) {
+                    processMethod(method, annotationClass, usedNames);
+                }
+            }
+
+            addLifeCycleMethods(clazz.getSuperclass(), usedNames);
+            for (Class<?> face : clazz.getInterfaces()) {
+                addLifeCycleMethods(face, usedNames);
+            }
+            
+         }
+
+        private Method[] getDeclaredMethods(Class<?> clazz) {
+            try {
+                return clazz.getDeclaredMethods();
+            } catch (Throwable e) {
+                handleReflectionError(clazz, e);
+            }
+
+            return EMPTY_METHODS;
+        }
+
+        private Field[] getDeclaredFields(Class<?> clazz) {
+            try {
+                return clazz.getDeclaredFields();
+            } catch (Throwable e) {
+                handleReflectionError(clazz, e);
+            }
+
+            return EMPTY_FIELDS;
+        }
+
+        private void handleReflectionError(Class<?> clazz, Throwable e) {
+            if (e != null) {
+                if ((e instanceof NoClassDefFoundError) || (e instanceof ClassNotFoundException)) {
+                    log.debug(String.format(
+                            "Class %s could not be resolved because of a class path error. Governator cannot further process the class.",
+                            clazz.getName()), e);
+                    return;
+                }
+
+                handleReflectionError(clazz, e.getCause());
+            }
+        }
+
+        private void checkForValidations(Field field) {
+            this.hasValidations =field.getAnnotationsByType(Constraint.class).length > 0;
+        }
+
+        private void processField(Field field, Class<? extends Annotation> annotationClass,
+                Multimap<Class<? extends Annotation>, String> usedNames) {
+            if (field.isAnnotationPresent(annotationClass)) {
+                String fieldName = field.getName();
+                if (!usedNames.get(annotationClass).contains(fieldName)) {
+                    field.setAccessible(true);
+                    usedNames.put(annotationClass, fieldName);
+                    fieldMap.put(annotationClass, field);
+                    try {
+                        fieldHandlesMap.put(field, new MethodHandle[] { 
+                                METHOD_HANDLE_LOOKUP.unreflectGetter(field),
+                                METHOD_HANDLE_LOOKUP.unreflectSetter(field) 
+                                });
+                    } catch (IllegalAccessException e) {
+                        // that's ok, will use reflected method
+                    }                
+                }
+            }
+        }
+
+        private void processMethod(Method method, Class<? extends Annotation> annotationClass,
+                Multimap<Class<? extends Annotation>, String> usedNames) {
+            if (method.isAnnotationPresent(annotationClass)) {
+                String methodName = method.getName();
+                if (!usedNames.get(annotationClass).contains(methodName)) {
+                    method.setAccessible(true);
+                    usedNames.put(annotationClass, methodName);
+                    methodMap.put(annotationClass, method);
+                    try {
+                        methodHandlesMap.put(method, METHOD_HANDLE_LOOKUP.unreflect(method));
+                    } catch (IllegalAccessException e) {
+                        // that's ok, will use reflected method
+                    }
+                }
+            }
+        }        
+        
     }
 
+    Map<Class<? extends Annotation>, Method[]> methodMap;
+    Map<Class<? extends Annotation>, Field[]> fieldMap;
+    Map<Class<? extends Annotation>, Annotation[]> classMap;
+    
     public LifecycleMethods(Class<?> clazz) {
-        addLifeCycleMethods(clazz, ArrayListMultimap.<Class<? extends Annotation>, String> create());
-        this.hasResources = fieldMap.containsKey(Resource.class) || 
-                fieldMap.containsKey(Resources.class) ||
-                methodMap.containsKey(Resource.class) ||
-                methodMap.containsKey(Resources.class) ||
-                classMap.containsKey(Resource.class) ||
-                classMap.containsKey(Resources.class);
+        LifecycleMethodsBuilder builder = new LifecycleMethodsBuilder(clazz, ArrayListMultimap.<Class<? extends Annotation>, String> create());
+        this.hasResources = builder.hasResources;
+        this.hasValidations = builder.hasValidations;
+        methodMap = new HashMap<>();
+        for (Map.Entry<Class<? extends Annotation>, Collection<Method>> entry : builder.methodMap.asMap().entrySet()) {
+            methodMap.put(entry.getKey(), entry.getValue().toArray(new Method[0]));
+        }
+        fieldMap = new HashMap<>();
+        for (Map.Entry<Class<? extends Annotation>, Collection<Field>> entry : builder.fieldMap.asMap().entrySet()) {
+            fieldMap.put(entry.getKey(), entry.getValue().toArray(new Field[0]));
+        }
+        classMap = new HashMap<>();
+        for (Map.Entry<Class<? extends Annotation>, Collection<Annotation>> entry : builder.classMap.asMap().entrySet()) {
+            
+            classMap.put(entry.getKey(), entry.getValue().toArray((Annotation[])Array.newInstance(entry.getKey().getClass(), 0)));
+        }
+
     }
 
     public boolean hasLifecycleAnnotations() {
-        return hasValidations || !methodMap.isEmpty() || !fieldMap.isEmpty();
+        return hasValidations;
     }
 
     public boolean hasResources() {
         return hasResources;
     }
 
-    public Collection<Method> methodsFor(Class<? extends Annotation> annotation) {
-        Collection<Method> methods = methodMap.get(annotation);
-        return (methods != null) ? methods : Collections.<Method>emptySet();
+    public Method[] methodsFor(Class<? extends Annotation> annotation) {
+        Method[] methods = methodMap.get(annotation);
+        return (methods != null) ? methods : EMPTY_METHODS;
     }
 
-    public Collection<Field> fieldsFor(Class<? extends Annotation> annotation) {
-        Collection<Field> fields = fieldMap.get(annotation);
-        return (fields != null) ? fields : Collections.<Field>emptySet();
+    public Field[] fieldsFor(Class<? extends Annotation> annotation) {
+        Field[] fields = fieldMap.get(annotation);
+        return (fields != null) ? fields : EMPTY_FIELDS;
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends Annotation> Collection<T> classAnnotationsFor(Class<T> annotation) {
-        return (Collection<T>)classMap.get(annotation);
+    public <T extends Annotation> T[] classAnnotationsFor(Class<T> annotation) {
+        return (T[])classMap.get(annotation);
     }
 
-    private void addLifeCycleMethods(Class<?> clazz, Multimap<Class<? extends Annotation>, String> usedNames) {
-        if (clazz == null) {
-            return;
-        }
-
-        for (Class<? extends Annotation> annotationClass : classAnnotations) {
-            if (clazz.isAnnotationPresent(annotationClass)) {
-                classMap.put(annotationClass, clazz.getAnnotation(annotationClass));
-            }
-        }
-
-        for (Field field : getDeclaredFields(clazz)) {
-            if (field.isSynthetic()) {
-                continue;
-            }
-
-            if (!hasValidations) {
-                checkForValidations(field);
-            }
-
-            for (Class<? extends Annotation> annotationClass : fieldAnnotations) {
-                processField(field, annotationClass, usedNames);
-            }
-        }
-
-        for (Method method : getDeclaredMethods(clazz)) {
-            if (method.isSynthetic() || method.isBridge()) {
-                continue;
-            }
-
-            for (Class<? extends Annotation> annotationClass : methodAnnotations) {
-                processMethod(method, annotationClass, usedNames);
-            }
-        }
-
-        addLifeCycleMethods(clazz.getSuperclass(), usedNames);
-        for (Class<?> face : clazz.getInterfaces()) {
-            addLifeCycleMethods(face, usedNames);
-        }
-    }
-
-    private Method[] getDeclaredMethods(Class<?> clazz) {
-        try {
-            return clazz.getDeclaredMethods();
-        } catch (Throwable e) {
-            handleReflectionError(clazz, e);
-        }
-
-        return EMPTY_METHODS;
-    }
-
-    private Field[] getDeclaredFields(Class<?> clazz) {
-        try {
-            return clazz.getDeclaredFields();
-        } catch (Throwable e) {
-            handleReflectionError(clazz, e);
-        }
-
-        return EMPTY_FIELDS;
-    }
-
-    private void handleReflectionError(Class<?> clazz, Throwable e) {
-        if (e != null) {
-            if ((e instanceof NoClassDefFoundError) || (e instanceof ClassNotFoundException)) {
-                log.debug(String.format(
-                        "Class %s could not be resolved because of a class path error. Governator cannot further process the class.",
-                        clazz.getName()), e);
-                return;
-            }
-
-            handleReflectionError(clazz, e.getCause());
-        }
-    }
-
-    private void checkForValidations(Field field) {
-        this.hasValidations =field.getAnnotationsByType(Constraint.class).length > 0;
-    }
-
-    private void processField(Field field, Class<? extends Annotation> annotationClass,
-            Multimap<Class<? extends Annotation>, String> usedNames) {
-        if (field.isAnnotationPresent(annotationClass)) {
-            String fieldName = field.getName();
-            if (!usedNames.get(annotationClass).contains(fieldName)) {
-                field.setAccessible(true);
-                usedNames.put(annotationClass, fieldName);
-                fieldMap.put(annotationClass, field);
-            }
-        }
-    }
-
-    private void processMethod(Method method, Class<? extends Annotation> annotationClass,
-            Multimap<Class<? extends Annotation>, String> usedNames) {
-        if (method.isAnnotationPresent(annotationClass)) {
-            String methodName = method.getName();
-            if (!usedNames.get(annotationClass).contains(methodName)) {
-                method.setAccessible(true);
-                usedNames.put(annotationClass, methodName);
-                methodMap.put(annotationClass, method);
-                try {
-                    methodHandlesMap.put(annotationClass, METHOD_HANDLE_LOOKUP.unreflect(method));
-                } catch (IllegalAccessException e) {
-                    // that's ok, will use reflected method
-                }
-            }
-        }
-    }
     
     public void methodInvoke(Class<? extends Annotation> annotation, Object obj) throws Exception {
         if  (methodMap.containsKey(annotation)) {
@@ -240,44 +291,69 @@ public class LifecycleMethods {
     }
     
     public static void methodInvoke(Method method, Object target) throws InvocationTargetException, IllegalAccessException {
-        try {
-            MethodHandle handler = methodHandlesMap.get(method);
-            if (handler == null) {
-                handler = METHOD_HANDLE_LOOKUP.unreflect(method);
-                methodHandlesMap.put(method, handler);
-            }            
-            
+        MethodHandle handler = methodHandlesMap.get(method);
+        if (handler != null) {
             try {
                 handler.invoke(target);
             } catch (Throwable e) {
                 throw new InvocationTargetException(e, "invokedynamic");
             }
-        } catch (IllegalAccessException e) {
-            // fall back to reflected invocation
+        }
+        else {
+            // fall through to reflected invocation
             method.invoke(target);
-            return;
-        }        
-    }
-
-    public static <T> T fieldGet(Field variableField, Object obj) throws InvocationTargetException, IllegalAccessException {
-        MethodHandle handler = METHOD_HANDLE_LOOKUP.unreflectGetter(variableField);
-        try {
-            return (T)handler.invoke(obj);
-        } catch (Throwable e) {
-            throw new InvocationTargetException(e);
         }
     }
 
-    public static <T> T fieldSet(Field field, Object object, Object value) throws InvocationTargetException, IllegalAccessException {
-        MethodHandle handler = methodHandlesMap.get(field);
-        if (handler == null) {
-            handler = METHOD_HANDLE_LOOKUP.unreflectSetter(field);
-            methodHandlesMap.put(field, handler);
+    @SuppressWarnings("unchecked")
+    public static <T> T fieldGet(Field field, Object obj) throws InvocationTargetException, IllegalAccessException {
+        MethodHandle[] fieldHandler = fieldHandlesMap.get(field);
+        if (fieldHandler == null) {
+            fieldHandler = updateFieldHandles(field);
         }
-        try {
-            return (T)handler.invoke(object, value);
-        } catch (Throwable e) {
-            throw new InvocationTargetException(e);
+        if (fieldHandler != EMPTY_FIELD_HANDLES) {
+            try {
+                return (T)fieldHandler[0].invoke(obj);
+            } catch (Throwable e) {
+                throw new InvocationTargetException(e, "invokedynamic");
+            }
+        }
+        else {
+            return (T)field.get(obj);
+        }
+    }
+
+    public static void fieldSet(Field field, Object object, Object value) throws InvocationTargetException, IllegalAccessException {
+        MethodHandle[] fieldHandler = fieldHandlesMap.get(field);
+        if (fieldHandler == null) {
+            fieldHandler = updateFieldHandles(field);
+        }
+        if (fieldHandler != EMPTY_FIELD_HANDLES) {
+            try {
+                fieldHandler[1].invoke(object, value);
+            } catch (Throwable e) {
+                throw new InvocationTargetException(e, "invokedynamic");
+            }
+        }
+        else {
+            field.set(object, value);
+        }
+    }
+
+    private final static MethodHandle[] EMPTY_FIELD_HANDLES = new MethodHandle[0];
+    private static MethodHandle[] updateFieldHandles(Field field) {
+        synchronized(fieldHandlesMap) {
+            MethodHandle[] handles = EMPTY_FIELD_HANDLES;
+            try {
+                handles = new MethodHandle[] { 
+                        METHOD_HANDLE_LOOKUP.unreflectGetter(field),
+                        METHOD_HANDLE_LOOKUP.unreflectSetter(field) 
+                        };
+            } catch (IllegalAccessException e) {
+                // that's ok, will use reflected method
+            }                                
+            fieldHandlesMap.put(field, handles);
+            return handles;
         }
     }
 

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ResourceMapper.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ResourceMapper.java
@@ -1,0 +1,232 @@
+package com.netflix.governator.lifecycle;
+
+import java.beans.Introspector;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Iterator;
+
+import javax.annotation.Resource;
+import javax.annotation.Resources;
+import javax.naming.NamingException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Injector;
+
+class ResourceMapper {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private Injector injector;
+    private final Collection<ResourceLocator> resourceLocators;
+    
+    ResourceMapper(Injector injector, Collection<ResourceLocator> resourceLocators) {
+        this.injector = injector;
+        this.resourceLocators = resourceLocators;
+    }
+    
+    public void map(Object obj, LifecycleMethods methods) throws Exception
+    {
+        if (methods.hasResources()) {        
+            Collection<Field> fieldResources = methods.fieldsFor(Resources.class);
+            if (!fieldResources.isEmpty()) {
+                for ( Field field : fieldResources )
+                {
+                    Resources resources = field.getAnnotation(Resources.class);
+                    for ( Resource resource : resources.value() )
+                    {
+                        setFieldResource(obj, field, resource);
+                    }
+                }
+            }
+    
+            Collection<Field> fieldResource = methods.fieldsFor(Resource.class);
+            if (!fieldResource.isEmpty()) {
+                for ( Field field : fieldResource )
+                {
+                    Resource resource = field.getAnnotation(Resource.class);
+                    setFieldResource(obj, field, resource);
+                }
+            }
+    
+            Collection<Method> methodResources = methods.methodsFor(Resources.class);
+            if (!methodResources.isEmpty()) {
+                for ( Method method : methodResources )
+                {
+                    Resources resources = method.getAnnotation(Resources.class);
+                    for ( Resource resource : resources.value() )
+                    {
+                        setMethodResource(obj, method, resource);
+                    }
+                }
+            }
+    
+            Collection<Method> methodResource = methods.methodsFor(Resource.class);
+            if (!methodResource.isEmpty()) {
+                for ( Method method : methodResource )
+                {
+                    Resource resource = method.getAnnotation(Resource.class);
+                    setMethodResource(obj, method, resource);
+                }
+            }
+    
+            Collection<Resources> classResources = methods.classAnnotationsFor(Resources.class);
+            if (!classResources.isEmpty()) {
+                for ( Resources resources : classResources )
+                {
+                    for ( Resource resource : resources.value() )
+                    {
+                        loadClassResource(resource);
+                    }
+                }
+            }
+    
+            Collection<Resource> classResource = methods.classAnnotationsFor(Resource.class);            
+            if (!classResource.isEmpty()) {
+                for ( Resource resource : classResource )
+                {
+                    loadClassResource(resource);
+                }
+            }
+        }
+    }
+
+    private void loadClassResource(Resource resource) throws Exception
+    {
+        if ( (resource.name().isEmpty()) || (resource.type() == Object.class) )
+        {
+            throw new Exception("Class resources must have both name() and type(): " + resource);
+        }
+        findResource(resource);
+    }
+
+    private void setMethodResource(Object obj, Method method, Resource resource) throws Exception
+    {
+        if ( (method.getParameterTypes().length != 1) || (method.getReturnType() != Void.TYPE) )
+        {
+            throw new Exception(String.format("%s.%s() is not a proper JavaBean setter.", obj.getClass().getName(), method.getName()));
+        }
+
+        String beanName = method.getName();
+        if ( beanName.toLowerCase().startsWith("set") )
+        {
+            beanName = beanName.substring("set".length());
+        }
+        beanName = Introspector.decapitalize(beanName);
+
+        String siteName = obj.getClass().getName() + "/" + beanName;
+        resource = adjustResource(resource, method.getParameterTypes()[0], siteName);
+        Object resourceObj = findResource(resource);
+        method.setAccessible(true);
+        method.invoke(obj, resourceObj);
+    }
+
+    private void setFieldResource(Object obj, Field field, Resource resource) throws Exception
+    {
+        String siteName = obj.getClass().getName() + "/" + field.getName();
+        Object resourceObj = findResource(adjustResource(resource, field.getType(), siteName));
+        field.setAccessible(true);
+        field.set(obj, resourceObj);
+    }
+
+    private Resource adjustResource(final Resource resource, final Class<?> siteType, final String siteName)
+    {
+        return new Resource()
+        {
+            @Override
+            public String name()
+            {
+                return (resource.name().length() == 0) ? siteName : resource.name();
+            }
+
+            /**
+             * Method needed for eventual java7 compatibility
+             */
+            public String lookup()
+            {
+                return name();
+            }
+
+            @Override
+            public Class<?> type()
+            {
+                return (resource.type() == Object.class) ? siteType : resource.type();
+            }
+
+            @Override
+            public AuthenticationType authenticationType()
+            {
+                return resource.authenticationType();
+            }
+
+            @Override
+            public boolean shareable()
+            {
+                return resource.shareable();
+            }
+
+            @Override
+            public String mappedName()
+            {
+                return resource.mappedName();
+            }
+
+            @Override
+            public String description()
+            {
+                return resource.description();
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType()
+            {
+                return resource.annotationType();
+            }
+        };
+    }
+
+    private Object findResource(Resource resource) throws Exception
+    {
+        if ( !resourceLocators.isEmpty() )
+        {
+            final Iterator<ResourceLocator> iterator = resourceLocators.iterator();
+            ResourceLocator locator = iterator.next();
+            ResourceLocator nextInChain = new ResourceLocator()
+            {
+                @Override
+                public Object locate(Resource resource, ResourceLocator nextInChain) throws Exception
+                {
+                    if ( iterator.hasNext() )
+                    {
+                        return iterator.next().locate(resource, this);
+                    }
+                    return defaultFindResource(resource);
+                }
+            };
+            return locator.locate(resource, nextInChain);
+        }
+        return defaultFindResource(resource);
+    }
+
+    private Object defaultFindResource(Resource resource) throws Exception
+    {
+        if ( injector == null )
+        {
+            throw new NamingException("Could not find resource: " + resource);
+        }
+
+        //noinspection unchecked     
+        log.debug("defaultFindResource using injector {}", System.identityHashCode(injector));
+        return injector.getInstance(resource.type());
+    }
+
+    public Injector getInjector() {
+        return injector;
+    }
+
+    public void setInjector(Injector injector) {
+        this.injector = injector;
+    }
+
+}

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LifeCycleFeaturesOnLegacyBuilderTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LifeCycleFeaturesOnLegacyBuilderTest.java
@@ -2,6 +2,7 @@ package com.netflix.governator.lifecycle;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
@@ -11,12 +12,10 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +28,14 @@ import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
 import com.netflix.governator.LifecycleManager;
 import com.netflix.governator.guice.LifecycleInjector;
+import com.netflix.governator.guice.LifecycleInjectorBuilder;
+import com.netflix.governator.guice.LifecycleInjectorMode;
 import com.netflix.governator.spi.LifecycleListener;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(DataProviderRunner.class)
 public class LifeCycleFeaturesOnLegacyBuilderTest {
     static class LifecycleSubject {
         private Logger logger = LoggerFactory.getLogger(LifecycleSubject.class);
@@ -81,20 +85,21 @@ public class LifeCycleFeaturesOnLegacyBuilderTest {
     }
     
     static class UsesNullable {
+        private AtomicBoolean preDestroyed = new AtomicBoolean(false);
         private LifecycleSubject subject;
         @Inject
         public void UsesNullable(@Nullable @Named("missing") LifecycleSubject subject) {
             this.subject = subject;
         }
         
-    }
-
-    private com.netflix.governator.lifecycle.LifecycleManager legacyLifecycleManager;
+        @PreDestroy
+        public void destroy() {
+            this.preDestroyed.set(true);
+        }
+   }
 
     @Mock
     private TestListener listener;
-
-    private LifecycleManager lifecycleManager;
 
     private Injector injector;
 
@@ -116,17 +121,17 @@ public class LifeCycleFeaturesOnLegacyBuilderTest {
         }
     }
 
-    @Before
-    public void init() throws Exception {
+    public com.netflix.governator.lifecycle.LifecycleManager init(LifecycleInjectorBuilder builder)  throws Exception {
         LifecycleSubject.instanceCounter.set(0);
         localScope = new LocalScope();
-        LifecycleInjector lifecycleInjector = LifecycleInjector.builder()
-                // .withMode(LifecycleInjectorMode.SIMULATED_CHILD_INJECTORS)
+        listener = Mockito.mock(TestListener.class);
+        LifecycleInjector lifecycleInjector = builder
                 .withAdditionalModules(new AbstractModule() {
                     @Override
                     protected void configure() {
                         bind(TestListener.class).toInstance(listener);
                         bindScope(LocalScoped.class, localScope);
+                        bind(UsesNullable.class);
                         bind(Key.get(LifecycleSubject.class, Names.named("missing"))).toProvider(Providers.of((LifecycleSubject)null));
                     }
 
@@ -143,87 +148,104 @@ public class LifeCycleFeaturesOnLegacyBuilderTest {
                     public LifecycleSubject thing2() {
                         return new LifecycleSubject("thing2");
                     }
-                }).build();
+                })
+                .requiringExplicitBindings()
+                .build();
         injector = lifecycleInjector.createInjector();
-        legacyLifecycleManager = lifecycleInjector.getLifecycleManager();
-
-        lifecycleManager = injector.getInstance(LifecycleManager.class);
-        legacyLifecycleManager.start();
+        com.netflix.governator.lifecycle.LifecycleManager lifecycleManager = lifecycleInjector.getLifecycleManager();
+        lifecycleManager.start();
+        return lifecycleManager;
     }
 
+    @UseDataProvider("builders")
     @Test
-    public void testPostActionsAndLifecycleListenersInvoked() {
-        assertNotNull(injector);
-        assertNotNull(lifecycleManager);
-
-        Mockito.verify(listener, Mockito.times(1)).onStarted();
-        Mockito.verify(listener, Mockito.times(1)).init();
-        Mockito.verify(listener, Mockito.times(0)).onStopped(Mockito.any(Throwable.class));
-        Mockito.verify(listener, Mockito.times(0)).shutdown();
-        legacyLifecycleManager.close();
+    public void testPostActionsAndLifecycleListenersInvoked(LifecycleInjectorBuilder builder) throws Exception {
+        try (com.netflix.governator.lifecycle.LifecycleManager lm = init(builder)) {
+            assertNotNull(injector);
+            assertNotNull(injector.getInstance(LifecycleManager.class));
+    
+            Mockito.verify(listener, Mockito.times(1)).onStarted();
+            Mockito.verify(listener, Mockito.times(1)).init();
+            Mockito.verify(listener, Mockito.times(0)).onStopped(Mockito.any(Throwable.class));
+            Mockito.verify(listener, Mockito.times(0)).shutdown();
+        }
         Mockito.verify(listener, Mockito.times(1)).onStopped(Mockito.any(Throwable.class));
         Mockito.verify(listener, Mockito.times(1)).onStopped(Mockito.any(Throwable.class));
     }
 
+    @UseDataProvider("builders")
     @Test
-    public void testScopeManagement() throws Exception {
-        LifecycleSubject thing2 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        localScope.enter();
-        injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing1")));
-        LifecycleSubject thing1 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing1")));
-        Assert.assertTrue(thing1.isPostConstructed());
-        Assert.assertFalse(thing1.isPreDestroyed());
-        Assert.assertTrue(thing2.isPostConstructed());
-        Assert.assertFalse(thing2.isPreDestroyed());
-        Assert.assertEquals(2, LifecycleSubject.getInstanceCount()); // thing1 and
-                                                                     // thing2
-        System.gc();
-        Thread.sleep(500);
-        Assert.assertFalse(thing2.isPreDestroyed());
+    public void testScopeManagement(LifecycleInjectorBuilder builder) throws Exception {
+        LifecycleSubject thing2 = null;
+        try (com.netflix.governator.lifecycle.LifecycleManager lm = init(builder)) {
+            thing2 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
+            localScope.enter();
+            injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing1")));
+            LifecycleSubject thing1 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing1")));
+            Assert.assertTrue(thing1.isPostConstructed());
+            Assert.assertFalse(thing1.isPreDestroyed());
+            Assert.assertTrue(thing2.isPostConstructed());
+            Assert.assertFalse(thing2.isPreDestroyed());
+            Assert.assertEquals(2, LifecycleSubject.getInstanceCount()); // thing1 and
+                                                                         // thing2
+            Assert.assertFalse(thing2.isPreDestroyed());
+            localScope.exit();
 
-        localScope.exit();
+            System.gc();
+            Thread.sleep(500);
+            Assert.assertTrue(thing1.isPreDestroyed());
+        }
         System.gc();
         Thread.sleep(500);
-        Assert.assertTrue(thing1.isPreDestroyed());
-        legacyLifecycleManager.close();
         Assert.assertTrue(thing2.isPreDestroyed());
-
     }
     
+    @UseDataProvider("builders")
     @Test
-    public void testSingletonScopeManagement() throws Exception {
-        LifecycleSubject thing2 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        Assert.assertTrue(thing2.isPostConstructed());
-        Assert.assertFalse(thing2.isPreDestroyed());
-        
-        injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        
-        Assert.assertEquals(1, LifecycleSubject.getInstanceCount()); 
-        
+    public void testSingletonScopeManagement(LifecycleInjectorBuilder builder) throws Exception {
+        LifecycleSubject thing2 = null;
+        try (com.netflix.governator.lifecycle.LifecycleManager lm = init(builder)) {
+            thing2 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
+            Assert.assertTrue(thing2.isPostConstructed());
+            Assert.assertFalse(thing2.isPreDestroyed());
+            
+            injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
+            injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
+            injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
+            
+            Assert.assertEquals(1, LifecycleSubject.getInstanceCount()); 
+    
+        }
         System.gc();
         Thread.sleep(500);
-        Assert.assertFalse(thing2.isPreDestroyed());
-
-        System.gc();
-        Thread.sleep(500);
-        legacyLifecycleManager.close();
         Assert.assertTrue(thing2.isPreDestroyed());
 
     }   
     
+    @UseDataProvider("builders")
     @Test
-    public void testNullableInjection() throws Exception {
-        LifecycleSubject thing2 = injector.getInstance(Key.get(LifecycleSubject.class, Names.named("thing2")));
-        Assert.assertTrue(thing2.isPostConstructed());
-        Assert.assertFalse(thing2.isPreDestroyed());
-        
-        UsesNullable nullableConsumer = injector.getInstance(UsesNullable.class);
-        Assert.assertNull(nullableConsumer.subject);
-        
-        legacyLifecycleManager.close();
-
+    public void testNullableInjection(LifecycleInjectorBuilder builder) throws Exception {
+        AtomicBoolean nullableConsumerDestroyed = null;
+        try (com.netflix.governator.lifecycle.LifecycleManager lm = init(builder)) {
+            UsesNullable nullableConsumer = injector.getInstance(UsesNullable.class);
+            nullableConsumerDestroyed = nullableConsumer.preDestroyed;
+            Assert.assertNull(nullableConsumer.subject);   
+        }
+        System.gc();
+        Thread.sleep(500);
+        Assert.assertTrue(nullableConsumerDestroyed.get());
     }       
     
+    @DataProvider
+    public static Object[][] builders()
+    {
+        return new Object[][]
+        {
+            new Object[] { "simulatedChildInjector", LifecycleInjector.builder().withMode(LifecycleInjectorMode.SIMULATED_CHILD_INJECTORS) },
+            new Object[] { "childInjector", LifecycleInjector.builder() },
+            new Object[] { "simulatedChildInjectorExplicitBindings", LifecycleInjector.builder().withMode(LifecycleInjectorMode.SIMULATED_CHILD_INJECTORS).requiringExplicitBindings() },
+            new Object[] { "childInjectorExplicitBindings", LifecycleInjector.builder().requiringExplicitBindings() }
+            
+        };
+    }
 }

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LocalScope.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LocalScope.java
@@ -16,13 +16,13 @@ public class LocalScope implements Scope {
     final ThreadLocal<Map<Key<?>, Object>> content = new ThreadLocal<Map<Key<?>, Object>>();
 
     public void enter() {
-        checkState(content.get() == null, "LocalScope already exists in thread {}", Thread.currentThread());
+        checkState(content.get() == null, "LocalScope already exists in thread %s", Thread.currentThread());
         content.set(Maps.<Key<?>, Object> newHashMap());           
     }
 
     public void exit() {
         Map<Key<?>, Object> scopeContents = content.get();
-        checkState(scopeContents != null, "No LocalScope found in thread {}", Thread.currentThread());
+        checkState(scopeContents != null, "No LocalScope found in thread %s", Thread.currentThread());
         scopeContents.clear();
         content.remove();
     }

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LocalScope.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LocalScope.java
@@ -13,16 +13,16 @@ import com.google.inject.Scopes;
 
 public class LocalScope implements Scope {
 
-    private final ThreadLocal<Map<Key<?>, Object>> content = new ThreadLocal<Map<Key<?>, Object>>();
+    final ThreadLocal<Map<Key<?>, Object>> content = new ThreadLocal<Map<Key<?>, Object>>();
 
     public void enter() {
-        checkState(content.get() == null, "LocalScope already exists in thread " + Thread.currentThread().getId());
+        checkState(content.get() == null, "LocalScope already exists in thread {}", Thread.currentThread());
         content.set(Maps.<Key<?>, Object> newHashMap());           
     }
 
     public void exit() {
         Map<Key<?>, Object> scopeContents = content.get();
-        checkState(scopeContents != null, "No LocalScope found in thread " + Thread.currentThread().getId());
+        checkState(scopeContents != null, "No LocalScope found in thread {}", Thread.currentThread());
         scopeContents.clear();
         content.remove();
     }
@@ -32,12 +32,12 @@ public class LocalScope implements Scope {
             public T get() {
                 Map<Key<?>, Object> scopedObjects = content.get();
                 if (scopedObjects == null) {
-                    throw new OutOfScopeException("No LocalScope found in thread " + Thread.currentThread().getId());
+                    throw new OutOfScopeException("No LocalScope found in thread " + Thread.currentThread());
                 }
 
                 @SuppressWarnings("unchecked")
                 T current = (T) scopedObjects.get(key);
-                if (current == null && !scopedObjects.containsKey(key)) {
+                if (current == null) {
                     current = unscoped.get();
 
                     // don't remember proxies; these exist only to serve

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
@@ -186,7 +186,7 @@ public class PreDestroyStressTest {
         finally {
             running.set(false);            
             es.shutdown();
-            es.awaitTermination(10, TimeUnit.SECONDS);
+            es.awaitTermination(10, TimeUnit.MINUTES);
         }
         es = null;
     }

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
@@ -39,8 +39,8 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 @RunWith(DataProviderRunner.class)
 public class PreDestroyStressTest {
     static final Key<LifecycleSubject> LIFECYCLE_SUBJECT_KEY = Key.get(LifecycleSubject.class);
-    private static final int TEST_TIME_IN_SECONDS = 60;  // run the stress test for this many seconds
-    private static final int CONCURRENCY_LEVEL = 200; // run the stress test with this many threads
+    private static final int TEST_TIME_IN_SECONDS = 10;  // run the stress test for this many seconds
+    private static final int CONCURRENCY_LEVEL = 20; // run the stress test with this many threads
 
     private final class ScopingModule extends AbstractModule {
         LocalScope localScope = new LocalScope();

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
@@ -38,8 +38,8 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
 @RunWith(DataProviderRunner.class)
 public class PreDestroyStressTest {
-    private static final int TEST_TIME_IN_SECONDS = 10;  // run the stress test for this many seconds
-    private static final int CONCURRENCY_LEVEL = 20; // run the stress test with this many threads
+    private static final int TEST_TIME_IN_SECONDS = 60;  // run the stress test for this many seconds
+    private static final int CONCURRENCY_LEVEL = 200; // run the stress test with this many threads
 
     private final class ScopingModule extends AbstractModule {
         LocalScope localScope = new LocalScope();
@@ -71,8 +71,6 @@ public class PreDestroyStressTest {
         private volatile boolean preDestroyed = false;
         private byte[] bulk;
         private final String toString = "LifecycleSubject@" + System.identityHashCode(this) + '[' + name + ']';
-        private final String postConstructMessage = "@PostConstruct called " + toString;
-        private final String preDestroyMessage = "@PreDestroy called " + toString;
 
         private static AtomicInteger instanceCounter = new AtomicInteger(0);
         private static AtomicInteger preDestroyCounter = new AtomicInteger(0);
@@ -85,21 +83,19 @@ public class PreDestroyStressTest {
         public LifecycleSubject(String name) {
             this.name = name;
             this.bulk = bulkTemplate.clone(); 
-            logger.info("created instance {} {}", this, instanceCounter.incrementAndGet());
+            logger.info("created instance {} {}", toString, instanceCounter.incrementAndGet());
             
         }
 
         @PostConstruct
         public void init() {
-            logger.info("{} {}", postConstructMessage, postConstructCounter.incrementAndGet());
-            logger.info(postConstructMessage);
+            logger.info("@PostConstruct called {} {}", toString, postConstructCounter.incrementAndGet());
             this.postConstructed = true;
         }
 
         @PreDestroy
         public void destroy() {
-            logger.info("{} {}", preDestroyMessage, preDestroyCounter.incrementAndGet());
-            logger.info(preDestroyMessage);
+            logger.info("@PreDestroy called {} {}", toString, preDestroyCounter.incrementAndGet());
             this.preDestroyed = true;
         }
 

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
@@ -186,7 +186,7 @@ public class PreDestroyStressTest {
         finally {
             running.set(false);            
             es.shutdown();
-            es.awaitTermination(10, TimeUnit.MINUTES);
+            es.awaitTermination(10, TimeUnit.SECONDS);
         }
         es = null;
     }

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/PreDestroyStressTest.java
@@ -39,8 +39,8 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 @RunWith(DataProviderRunner.class)
 public class PreDestroyStressTest {
     static final Key<LifecycleSubject> LIFECYCLE_SUBJECT_KEY = Key.get(LifecycleSubject.class);
-    private static final int TEST_TIME_IN_SECONDS = 10;  // run the stress test for this many seconds
-    private static final int CONCURRENCY_LEVEL = 20; // run the stress test with this many threads
+    private static final int TEST_TIME_IN_SECONDS = 60;  // run the stress test for this many seconds
+    private static final int CONCURRENCY_LEVEL = 200; // run the stress test with this many threads
 
     private final class ScopingModule extends AbstractModule {
         LocalScope localScope = new LocalScope();


### PR DESCRIPTION
Tuning with an eye towards use of short-lived scopes.  Changes based on a test load of 200 threads injecting scoped instances with a ttl between 0-500ms; see PreDestroyStressTest.  Some of the more significant improvements:

- 'invoke dynamic' invocation of lifecycle methods and configuration fields
- reduced lock contention in PreDestroyMonitor
- reduced partition contention in LifecycleManager.objectStates
- caching of @PreDestroy parsing in LifecycleManager
- caching of @Resource detection in LifecycleMethods

Also includes a bug fix to allow use of 'Binder.requireExplicitBindings()' feature and bumped Guice dependency to 4.1.0

Update - added bug fix for nested LifecycleListener notification