### PR TITLE
Add support for AutoBindSingleton

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ subprojects {
         jcenter()
     }
 
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+    
     group = "com.netflix.governator"
 
     dependencies {

--- a/governator-api/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
+++ b/governator-api/src/main/java/com/netflix/governator/annotations/AutoBindSingleton.java
@@ -39,7 +39,7 @@ public @interface AutoBindSingleton
      *
      * @return base class/interface to bind to
      */
-    Class<?>  value() default AutoBindSingleton.class;
+    Class<?>  value() default Void.class;
 
     /**
      * This is a synonym for {@link #value()}. It exists to make the annotation
@@ -48,7 +48,7 @@ public @interface AutoBindSingleton
      *
      * @return base class/interface to bind to
      */
-    Class<?>  baseClass() default AutoBindSingleton.class;
+    Class<?>  baseClass() default Void.class;
 
     /**
      * If true, instances are gathered into a Set using Guice's Multibinder. You must

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile     "com.google.inject:guice:${guice_version}"
     compile     "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile     "com.google.inject.extensions:guice-grapher:${guice_version}"    // should be provided - only if you want graphing
+    compile     "org.ow2.asm:asm:5.0.4"
 
     testCompile "org.hamcrest:hamcrest-core:${hamcrest_version}"
     testCompile "org.hamcrest:hamcrest-library:${hamcrest_version}"

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile     "com.google.inject:guice:${guice_version}"
     compile     "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile     "com.google.inject.extensions:guice-grapher:${guice_version}"    // should be provided - only if you want graphing
-    compile     "org.ow2.asm:asm:5.0.4"
 
     testCompile "org.hamcrest:hamcrest-core:${hamcrest_version}"
     testCompile "org.hamcrest:hamcrest-library:${hamcrest_version}"

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     compile     "com.google.inject:guice:${guice_version}"
     compile     "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile     "com.google.inject.extensions:guice-grapher:${guice_version}"    // should be provided - only if you want graphing
-    compile     "org.ow2.asm:asm:5.0.4"
 
     testCompile "org.hamcrest:hamcrest-core:${hamcrest_version}"
     testCompile "org.hamcrest:hamcrest-library:${hamcrest_version}"
@@ -17,7 +16,4 @@ dependencies {
     test {
         useJUnit()
     }
-
-
-
 }

--- a/governator-core/build.gradle
+++ b/governator-core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile     "com.google.inject:guice:${guice_version}"
     compile     "com.google.inject.extensions:guice-multibindings:${guice_version}"
     compile     "com.google.inject.extensions:guice-grapher:${guice_version}"    // should be provided - only if you want graphing
+    compile     "org.ow2.asm:asm:5.0.4"
 
     testCompile "org.hamcrest:hamcrest-core:${hamcrest_version}"
     testCompile "org.hamcrest:hamcrest-library:${hamcrest_version}"
@@ -16,4 +17,7 @@ dependencies {
     test {
         useJUnit()
     }
+
+
+
 }

--- a/governator-core/src/main/java/com/netflix/governator/AutoBindSingletonAnnotatedClassScanner.java
+++ b/governator-core/src/main/java/com/netflix/governator/AutoBindSingletonAnnotatedClassScanner.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Set;
 
+import javax.inject.Scope;
 import javax.inject.Singleton;
 
 public class AutoBindSingletonAnnotatedClassScanner implements AnnotatedClassScanner {
@@ -59,8 +60,8 @@ public class AutoBindSingletonAnnotatedClassScanner implements AnnotatedClassSca
         
         Class<?> annotationBaseClass = getAnnotationBaseClass(annotation);
         
-        // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null
-        if ( annotationBaseClass != AutoBindSingleton.class ) {
+        // Void.class is used as a marker to mean "default" because annotation defaults cannot be null
+        if ( annotationBaseClass != Void.class ) {
             Object foundBindingClass = searchForBaseClass(clazz, annotationBaseClass, Sets.newHashSet());
             Preconditions.checkArgument(foundBindingClass != null, String.format("AutoBindSingleton class %s does not implement or extend %s", clazz.getName(), annotationBaseClass.getName()));
 
@@ -126,7 +127,7 @@ public class AutoBindSingletonAnnotatedClassScanner implements AnnotatedClassSca
     private boolean hasScopeAnnotation(Class<?> clazz) {
         Annotation scopeAnnotation = null;
         for (Annotation annot : clazz.getAnnotations()) {
-            if (annot.annotationType().isAnnotationPresent(ScopeAnnotation.class)) {
+            if (annot.annotationType().isAnnotationPresent(ScopeAnnotation.class) || annot.annotationType().isAnnotationPresent(Scope.class)) {
                 Preconditions.checkState(scopeAnnotation == null, "Multiple scopes not allowed");
                 scopeAnnotation = annot;
             }
@@ -137,9 +138,9 @@ public class AutoBindSingletonAnnotatedClassScanner implements AnnotatedClassSca
     private Class<?> getAnnotationBaseClass(AutoBindSingleton annotation) {
         Class<?> annotationValue = annotation.value();
         Class<?> annotationBaseClass = annotation.baseClass();
-        Preconditions.checkState((annotationValue == AutoBindSingleton.class) || (annotationBaseClass == AutoBindSingleton.class), "@AutoBindSingleton cannot have both value and baseClass set");
+        Preconditions.checkState((annotationValue == Void.class) || (annotationBaseClass == Void.class), "@AutoBindSingleton cannot have both value and baseClass set");
 
-        return (annotationBaseClass != AutoBindSingleton.class) ? annotationBaseClass : annotationValue;
+        return (annotationBaseClass != Void.class) ? annotationBaseClass : annotationValue;
     }
 
     private Object searchForBaseClass(Class<?> clazz, Class<?> annotationBaseClass, Set<Object> usedSet) {

--- a/governator-core/src/main/java/com/netflix/governator/AutoBindSingletonAnnotatedClassScanner.java
+++ b/governator-core/src/main/java/com/netflix/governator/AutoBindSingletonAnnotatedClassScanner.java
@@ -1,0 +1,179 @@
+package com.netflix.governator;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.ScopeAnnotation;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.ScopedBindingBuilder;
+import com.google.inject.internal.MoreTypes;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.governator.annotations.AutoBindSingleton;
+import com.netflix.governator.guice.lazy.LazySingletonScope;
+import com.netflix.governator.spi.AnnotatedClassScanner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+public class AutoBindSingletonAnnotatedClassScanner implements AnnotatedClassScanner {
+    private static final Logger LOG = LoggerFactory.getLogger(AutoBindSingletonAnnotatedClassScanner.class);
+    
+    @Override
+    public Class<? extends Annotation> annotationClass() {
+        return AutoBindSingleton.class;
+    }
+
+    @Override
+    public <T> void applyTo(Binder binder, Annotation annotation, Key<T> key) {
+        AutoBindSingleton abs = (AutoBindSingleton)annotation;
+        Class clazz = key.getTypeLiteral().getRawType();
+        if ( Module.class.isAssignableFrom(clazz) ) {
+            try {
+                binder.install((Module)clazz.newInstance());
+            } catch (Exception e) {
+                binder.addError("Failed to install @AutoBindSingleton module " + clazz.getName());
+                binder.addError(e);
+            }
+        } else {
+            bindAutoBindSingleton(binder, abs, clazz);
+        }
+    }
+
+    private void bindAutoBindSingleton(Binder binder, AutoBindSingleton annotation, Class<?> clazz) {
+        LOG.info("Installing @AutoBindSingleton '{}'", clazz.getName());
+        LOG.info("***** @AutoBindSingleton for '{}' is deprecated as of 2015-10-10.\nPlease use a Guice module with bind({}.class).asEagerSingleton() instead.\nSee https://github.com/Netflix/governator/wiki/Auto-Binding", 
+                clazz.getName(), clazz.getSimpleName() );
+        
+        Singleton singletonAnnotation = clazz.getAnnotation(Singleton.class);
+        if (singletonAnnotation == null) {
+            LOG.info("***** {} should also be annotated with @Singleton to ensure singleton behavior", clazz.getName());
+        }
+        
+        Class<?> annotationBaseClass = getAnnotationBaseClass(annotation);
+        
+        // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null
+        if ( annotationBaseClass != AutoBindSingleton.class ) {
+            Object foundBindingClass = searchForBaseClass(clazz, annotationBaseClass, Sets.newHashSet());
+            Preconditions.checkArgument(foundBindingClass != null, String.format("AutoBindSingleton class %s does not implement or extend %s", clazz.getName(), annotationBaseClass.getName()));
+
+            if ( foundBindingClass instanceof Class ) {
+                if ( annotation.multiple() ) {
+                    Multibinder<?> multibinder = Multibinder.newSetBinder(binder, (Class)foundBindingClass);
+                    //noinspection unchecked
+                    applyScope(multibinder
+                            .addBinding()
+                            .to((Class)clazz), 
+                        clazz, annotation);
+                } else {
+                    //noinspection unchecked
+                    applyScope(binder
+                            .withSource(getCurrentStackElement())
+                            .bind((Class)foundBindingClass)
+                            .to(clazz),
+                        clazz, annotation);
+                }
+            }
+            else if ( foundBindingClass instanceof Type ) {
+                TypeLiteral typeLiteral = TypeLiteral.get((Type)foundBindingClass);
+                if ( annotation.multiple() ) {
+                    //noinspection unchecked
+                    applyScope(Multibinder.newSetBinder(binder, typeLiteral)
+                            .addBinding()
+                            .to((Class)clazz),
+                        clazz, annotation);
+                } else {
+                    //noinspection unchecked
+                    applyScope(binder
+                            .withSource(getCurrentStackElement())
+                            .bind(typeLiteral).to(clazz), 
+                        clazz, annotation);
+                }
+            } else {
+                binder.addError("Unexpected binding class: " + foundBindingClass);
+            }
+        }
+        else {
+            Preconditions.checkState(!annotation.multiple(), "@AutoBindSingleton(multiple=true) must have either value or baseClass set");
+            applyScope(binder
+                    .withSource(getCurrentStackElement())
+                    .bind(clazz), 
+                clazz, annotation);
+        }
+    }
+    
+    private StackTraceElement getCurrentStackElement() {
+        return Thread.currentThread().getStackTrace()[1];
+    }
+
+    private void applyScope(ScopedBindingBuilder builder, Class<?> clazz, AutoBindSingleton annotation) {
+        if (hasScopeAnnotation(clazz)) {
+            // Honor scoped annotations first
+        } else if (annotation.eager()) {
+            builder.asEagerSingleton();
+        } else  {
+            builder.in(LazySingletonScope.get());
+        }
+    }
+    
+    private boolean hasScopeAnnotation(Class<?> clazz) {
+        Annotation scopeAnnotation = null;
+        for (Annotation annot : clazz.getAnnotations()) {
+            if (annot.annotationType().isAnnotationPresent(ScopeAnnotation.class)) {
+                Preconditions.checkState(scopeAnnotation == null, "Multiple scopes not allowed");
+                scopeAnnotation = annot;
+            }
+        }
+        return scopeAnnotation != null;
+    }
+    
+    private Class<?> getAnnotationBaseClass(AutoBindSingleton annotation) {
+        Class<?> annotationValue = annotation.value();
+        Class<?> annotationBaseClass = annotation.baseClass();
+        Preconditions.checkState((annotationValue == AutoBindSingleton.class) || (annotationBaseClass == AutoBindSingleton.class), "@AutoBindSingleton cannot have both value and baseClass set");
+
+        return (annotationBaseClass != AutoBindSingleton.class) ? annotationBaseClass : annotationValue;
+    }
+
+    private Object searchForBaseClass(Class<?> clazz, Class<?> annotationBaseClass, Set<Object> usedSet) {
+        if (clazz == null) {
+            return null;
+        }
+
+        if (clazz.equals(annotationBaseClass)) {
+            return clazz;
+        }
+
+        if (!usedSet.add(clazz)) {
+            return null;
+        }
+
+        for (Type type : clazz.getGenericInterfaces()) {
+            if (MoreTypes.getRawType(type).equals(annotationBaseClass)) {
+                return type;
+            }
+        }
+
+        if (clazz.getGenericSuperclass() != null) {
+            if (MoreTypes.getRawType(clazz.getGenericSuperclass()).equals(annotationBaseClass)) {
+                return clazz.getGenericSuperclass();
+            }
+        }
+
+        for (Class<?> interfaceClass : clazz.getInterfaces()) {
+            Object foundBindingClass = searchForBaseClass(interfaceClass, annotationBaseClass, usedSet);
+            if (foundBindingClass != null) {
+                return foundBindingClass;
+            }
+        }
+
+        return searchForBaseClass(clazz.getSuperclass(), annotationBaseClass, usedSet);
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
@@ -8,6 +8,7 @@ import com.google.common.base.Predicates;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.spi.Elements;
 import com.netflix.governator.internal.scanner.ClasspathUrlDecoder;
 import com.netflix.governator.internal.scanner.DirectoryClassFilter;
 import com.netflix.governator.spi.AnnotatedClassScanner;
@@ -132,11 +133,11 @@ public class ScanningModuleBuilder {
     }
     
     public Module build() {
-        return build(classLoader, new ArrayList<>(scanners), new ArrayList<>(packages), Predicates.not(excludeRule));
-    }
-    
-    private Module build(final ClassLoader classLoader, final List<AnnotatedClassScanner> scanners, final List<String> packages, final Predicate<String> includeRule) {
-        return new AbstractModule() {
+        final Predicate<String> includeRule = Predicates.not(excludeRule);
+        // Generate the list of elements here and immediately create a module from them.  This ensures
+        // that the class path is canned only once as a Module's configure method may be called multiple
+        // times by Guice.
+        return Elements.getModule(Elements.getElements(new AbstractModule() {
             @Override
             public void configure() {
                 for ( String basePackage : packages )  {
@@ -225,6 +226,6 @@ public class ScanningModuleBuilder {
                     }
                 }, SKIP_CODE);
             }
-        };
+        }));
     };
 }

--- a/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
@@ -1,37 +1,22 @@
 package com.netflix.governator;
 
-import static org.objectweb.asm.ClassReader.SKIP_CODE;
-import static org.objectweb.asm.Type.getType;
-
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.spi.Elements;
-import com.netflix.governator.internal.scanner.ClasspathUrlDecoder;
-import com.netflix.governator.internal.scanner.DirectoryClassFilter;
 import com.netflix.governator.spi.AnnotatedClassScanner;
 
-import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
-
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 
 /**
  * When installed this module will scan for annotated classes and creating appropriate bindings.  
@@ -134,6 +119,18 @@ public class ScanningModuleBuilder {
         });
     }
     
+    private boolean isInTargetPackages(String pkgName) {
+        if (packages.isEmpty()) {
+            return true;
+        }
+        for ( String pkg : packages )  {
+            if (pkgName.startsWith(pkg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     public Module build() {
         final Predicate<String> includeRule = Predicates.not(excludeRule);
         // Generate the list of elements here and immediately create a module from them.  This ensures
@@ -142,91 +139,31 @@ public class ScanningModuleBuilder {
         return Elements.getModule(Elements.getElements(new AbstractModule() {
             @Override
             public void configure() {
-                for ( String basePackage : packages )  {
-                    try {
-                        String basePackageWithSlashes = basePackage.replace(".", "/");
-                        for (URL url : Collections.list(classLoader.getResources(basePackageWithSlashes))) {
+                final ClassPath classPath;
+                try {
+                    classPath = ClassPath.from(classLoader);
+                } catch (IOException e) {
+                    this.addError(e);
+                    return;
+                }
+                
+                for (ClassInfo classInfo : classPath.getAllClasses()) {
+                    if (!isInTargetPackages(classInfo.getPackageName()) || !includeRule.apply(classInfo.getName())) {
+                        continue;
+                    }
+                    
+                    for (AnnotatedClassScanner scanner : scanners) {
+                        Class<?> cls = classInfo.load();
+                        if (cls.isAnnotationPresent(scanner.annotationClass())) {
                             try {
-                                if ( isJarURL(url)) {
-                                    String jarPath = url.getFile();
-                                    if ( jarPath.contains("!") ) {
-                                        jarPath = jarPath.substring(0, jarPath.indexOf("!"));
-                                        url = new URL(jarPath);
-                                    }
-                                    File file = ClasspathUrlDecoder.toFile(url);
-                                    try (JarFile jar = new JarFile(file)) {
-                                        for (JarEntry entry : Collections.list(jar.entries())) {
-                                            try {
-                                                if ( entry.getName().endsWith(".class") && entry.getName().startsWith(basePackageWithSlashes)) {
-                                                    try (InputStream is = jar.getInputStream(entry)) {
-                                                        handleClass(is);
-                                                    }
-                                                }
-                                            } catch (Exception e) {
-                                                addError("Unable to scan JarEntry '%s' in '%s'. %s", entry.getName(), file.getCanonicalPath(), e.getMessage());
-                                                addError(e);
-                                            }
-                                        }
-                                    } catch (Exception e ) {
-                                        addError("Unable to scan '%s'. %s", file.getCanonicalPath(), e.getMessage());
-                                        addError(e);
-                                    }
-                                } else {
-                                    DirectoryClassFilter filter = new DirectoryClassFilter(classLoader);
-                                    for ( String className : filter.filesInPackage(url, basePackage) ) {
-                                        try (InputStream is = filter.bytecodeOf(className)) {
-                                            handleClass(is);
-                                        }
-                                    }
-                                }
+                                scanner.applyTo(binder(), cls.getAnnotation(scanner.annotationClass()), Key.get(cls));
                             } catch (Exception e) {
-                                addError("Unable to scan jar '%s'. %s ", url, e.getMessage());
-                                addError(e);
+                                binder().addError("Failed process scanned class %s", classInfo.getName());
+                                binder().addError(e);
                             }
                         }
-                    } catch ( Exception e ) {
-                        addError("Classpath scanning failed for package \'" + basePackage + "\'");
-                        addError(e);
                     }
                 }
-            }
-            
-            private boolean isJarURL(URL url) {
-                String protocol = url.getProtocol();
-                return "zip".equals(protocol) || "jar".equals(protocol) ||
-                        ("file".equals(protocol) && url.getPath().endsWith(".jar"));
-            }
-            
-            private void handleClass(InputStream inputStream) throws IOException {
-                new ClassReader(inputStream).accept(new ClassVisitor(Opcodes.ASM5) {
-                    private String className;
-                    
-                    @Override
-                    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-                        className = name.replace('/', '.');
-                        super.visit(version, access, name, signature, superName, interfaces);
-                    }
-                    
-                    @Override
-                    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-                        Type type = getType(desc);
-                        if (includeRule.apply(className)) {
-                            for (AnnotatedClassScanner scanner : scanners) {
-                                if (getType(scanner.annotationClass()).equals(type)) {
-                                    try {
-                                        Class<?> cls = Class.forName(className, false, classLoader);
-                                        scanner.applyTo(binder(), cls.getAnnotation(scanner.annotationClass()), Key.get(cls));
-                                    } catch (ClassNotFoundException e) {
-                                        binder().addError(e);
-                                        binder().addError("Failed process scanned class %s", className);
-                                    }
-                                }
-                            }
-                        }
-                        
-                        return super.visitAnnotation(desc, visible);
-                    }
-                }, SKIP_CODE);
             }
         }));
     };

--- a/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
@@ -1,0 +1,230 @@
+package com.netflix.governator;
+
+import static org.objectweb.asm.ClassReader.SKIP_CODE;
+import static org.objectweb.asm.Type.getType;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.netflix.governator.internal.scanner.ClasspathUrlDecoder;
+import com.netflix.governator.internal.scanner.DirectoryClassFilter;
+import com.netflix.governator.spi.AnnotatedClassScanner;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * When installed this module will scan for annotated classes and creating appropriate bindings.  
+ * The specific annotation to scan and binding semantics are captured in a {@link AnnotatedClassScanner}.
+ * 
+ * The following example shows how to install a module that creates bindings for classes containing
+ * the AutoBindSingleton annotation.
+ * 
+ * <pre>
+ * {@code 
+ * install(new ScanningModuleBuilder().
+ *      .forPackages("org.example")
+ *      .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
+ *      .build()
+ * }
+ * </pre>
+ */
+public class ScanningModuleBuilder {
+    private List<String> packages = new ArrayList<>();
+    private List<AnnotatedClassScanner> scanners = new ArrayList<>();
+    private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    private Predicate<String> excludeRule = Predicates.alwaysFalse();
+    
+    /**
+     * Specify a custom class loader to use.  If not specified Thread.currentThread().getContextClassLoader()
+     * will be used.
+     * 
+     * @param classLoader
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder usingClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        return this;
+    }
+    
+    /**
+     * Set of packages to scan.  
+     * 
+     * @param packages
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder forPackages(String... packages) {
+        return forPackages(Arrays.asList(packages));
+    }
+    
+    /**
+     * Set of packages to scan.  
+     * 
+     * @param packages
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder forPackages(Collection<String> packages) {
+        this.packages = new ArrayList<>(packages);
+        return this;
+    }
+    
+    /**
+     * Specify an {@link AnnotatedClassScanner} to process classes from the set of specified packages.  
+     * 
+     * @param packages
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder scanForAnnotatedClasses(AnnotatedClassScanner scanner) {
+        scanners.add(scanner);
+        return this;
+    }
+    
+    /**
+     * Exclude bindings for any class matching the specified predicate.
+     * @param classes
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder excludeClasses(Predicate<String> predicate) {
+        excludeRule = Predicates.or(excludeRule, predicate);
+        return this;
+    }
+
+    /**
+     * Exclude specific classes from the classpath scanning.
+     * @param classes
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder excludeClasses(String... classes) {
+        return excludeClasses(Arrays.asList(classes));
+    }
+    
+    /**
+     * Exclude specific classes from the classpath scanning.
+     * @param classes
+     * @return Builder for chaining
+     */
+    public ScanningModuleBuilder excludeClasses(Collection<String> classes) {
+        final Collection<String> toTest = new HashSet<>(classes);
+        return excludeClasses(new Predicate<String>() {
+           @Override
+            public boolean apply(String className) {
+               return toTest.contains(className);
+            }
+        });
+    }
+    
+    public Module build() {
+        return build(classLoader, new ArrayList<>(scanners), new ArrayList<>(packages), Predicates.not(excludeRule));
+    }
+    
+    private Module build(final ClassLoader classLoader, final List<AnnotatedClassScanner> scanners, final List<String> packages, final Predicate<String> includeRule) {
+        return new AbstractModule() {
+            @Override
+            public void configure() {
+                for ( String basePackage : packages )  {
+                    try {
+                        String basePackageWithSlashes = basePackage.replace(".", "/");
+                        for (URL url : Collections.list(classLoader.getResources(basePackageWithSlashes))) {
+                            try {
+                                if ( isJarURL(url)) {
+                                    String jarPath = url.getFile();
+                                    if ( jarPath.contains("!") ) {
+                                        jarPath = jarPath.substring(0, jarPath.indexOf("!"));
+                                        url = new URL(jarPath);
+                                    }
+                                    File file = ClasspathUrlDecoder.toFile(url);
+                                    try (JarFile jar = new JarFile(file)) {
+                                        for (JarEntry entry : Collections.list(jar.entries())) {
+                                            try {
+                                                if ( entry.getName().endsWith(".class") && entry.getName().startsWith(basePackageWithSlashes)) {
+                                                    try (InputStream is = jar.getInputStream(entry)) {
+                                                        handleClass(is);
+                                                    }
+                                                }
+                                            } catch (Exception e) {
+                                                addError("Unable to scan JarEntry '%s' in '%s'. %s", entry.getName(), file.getCanonicalPath(), e.getMessage());
+                                                addError(e);
+                                            }
+                                        }
+                                    } catch (Exception e ) {
+                                        addError("Unable to scan '%s'. %s", file.getCanonicalPath(), e.getMessage());
+                                        addError(e);
+                                    }
+                                } else {
+                                    DirectoryClassFilter filter = new DirectoryClassFilter(classLoader);
+                                    for ( String className : filter.filesInPackage(url, basePackage) ) {
+                                        try (InputStream is = filter.bytecodeOf(className)) {
+                                            handleClass(is);
+                                        }
+                                    }
+                                }
+                            } catch (Exception e) {
+                                addError("Unable to scan jar '%s'. %s ", url, e.getMessage());
+                                addError(e);
+                            }
+                        }
+                    } catch ( Exception e ) {
+                        addError("Classpath scanning failed for package \'" + basePackage + "\'");
+                        addError(e);
+                    }
+                }
+            }
+            
+            private boolean isJarURL(URL url) {
+                String protocol = url.getProtocol();
+                return "zip".equals(protocol) || "jar".equals(protocol) ||
+                        ("file".equals(protocol) && url.getPath().endsWith(".jar"));
+            }
+            
+            private void handleClass(InputStream inputStream) throws IOException {
+                new ClassReader(inputStream).accept(new ClassVisitor(Opcodes.ASM5) {
+                    private String className;
+                    
+                    @Override
+                    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                        className = name.replace('/', '.');
+                        super.visit(version, access, name, signature, superName, interfaces);
+                    }
+                    
+                    @Override
+                    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                        Type type = getType(desc);
+                        if (includeRule.apply(className)) {
+                            for (AnnotatedClassScanner scanner : scanners) {
+                                if (getType(scanner.annotationClass()).equals(type)) {
+                                    try {
+                                        Class<?> cls = Class.forName(className, false, classLoader);
+                                        scanner.applyTo(binder(), cls.getAnnotation(scanner.annotationClass()), Key.get(cls));
+                                    } catch (ClassNotFoundException e) {
+                                        binder().addError(e);
+                                        binder().addError("Failed process scanned class %s", className);
+                                    }
+                                }
+                            }
+                        }
+                        
+                        return super.visitAnnotation(desc, visible);
+                    }
+                }, SKIP_CODE);
+            }
+        };
+    };
+}

--- a/governator-core/src/main/java/com/netflix/governator/internal/scanner/ClasspathUrlDecoder.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/scanner/ClasspathUrlDecoder.java
@@ -1,4 +1,4 @@
-package com.netflix.governator.lifecycle;
+package com.netflix.governator.internal.scanner;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/governator-core/src/main/java/com/netflix/governator/internal/scanner/DirectoryClassFilter.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/scanner/DirectoryClassFilter.java
@@ -16,6 +16,9 @@
 
 package com.netflix.governator.internal.scanner;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -27,8 +30,9 @@ import java.util.List;
 /**
  * Locates files within a directory-based classpath resource that are contained with a particular base package.
  */
-public class DirectoryClassFilter
-{
+public class DirectoryClassFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(DirectoryClassFilter.class);
+    
     private final ClassLoader loader;
 
     public DirectoryClassFilter(ClassLoader loader) {
@@ -65,8 +69,8 @@ public class DirectoryClassFilter
         throw new IOException("Unable to open class with name " + className + " because the class loader was unable to locate it");
     }
 
-    @SuppressWarnings("ConstantConditions")
     private void scanDir(File dir, List<String> classNames, String packageName) {
+        LOG.info("Scanning dir {}", packageName);
         File[] files = dir.listFiles();
         for (File file : files) {
             if (file.isDirectory()) {

--- a/governator-core/src/main/java/com/netflix/governator/internal/scanner/DirectoryClassFilter.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/scanner/DirectoryClassFilter.java
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-package com.netflix.governator.lifecycle;
+package com.netflix.governator.internal.scanner;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -27,11 +27,11 @@ import java.util.List;
 /**
  * Locates files within a directory-based classpath resource that are contained with a particular base package.
  */
-class DirectoryClassFilter
+public class DirectoryClassFilter
 {
     private final ClassLoader loader;
 
-    DirectoryClassFilter(ClassLoader loader) {
+    public DirectoryClassFilter(ClassLoader loader) {
         this.loader = loader;
     }
 

--- a/governator-core/src/main/java/com/netflix/governator/spi/AnnotatedClassScanner.java
+++ b/governator-core/src/main/java/com/netflix/governator/spi/AnnotatedClassScanner.java
@@ -1,0 +1,27 @@
+package com.netflix.governator.spi;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * @see ScanningModuleBuidler
+ */
+public interface AnnotatedClassScanner {
+    /**
+     * @return Annotation class handled by this scanner
+     */
+    Class<? extends Annotation> annotationClass();
+    
+    /**
+     * Apply the found class on the provided binder.  This can result in 0 or more bindings being
+     * created
+     * 
+     * @param binder The binder on which to create new bindings
+     * @param annotation The found annotation
+     * @param key Key for the found class
+     */
+    <T> void applyTo(Binder binder, Annotation annotation, Key<T> key);
+
+}

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -22,7 +22,7 @@ public class AutoBindSingletonTest {
         final Set<Class> created = new HashSet<>();
         try (LifecycleInjector injector = InjectorBuilder.fromModules(
             new ScanningModuleBuilder()
-                .forPackages("com.netflix.governator.package1")
+                .forPackages("com.netflix.governator.package1", "com.netflix")
                 .addScanner(new AutoBindSingletonAnnotatedClassScanner())
                 .build(),
             new AbstractModule() {
@@ -57,7 +57,7 @@ public class AutoBindSingletonTest {
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
                 .addScanner(new AutoBindSingletonAnnotatedClassScanner())
-                .excludeClasses(AutoBindSingletonConcrete.class.getName())
+                .excludeClassesIn(AutoBindSingletonConcrete.class.getName())
                 .build())
         .createInjector()) {
             Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -57,7 +57,7 @@ public class AutoBindSingletonTest {
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
                 .addScanner(new AutoBindSingletonAnnotatedClassScanner())
-                .excludeClassesIn(AutoBindSingletonConcrete.class.getName())
+                .excludeClasses(AutoBindSingletonConcrete.class)
                 .build())
         .createInjector()) {
             Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -1,0 +1,66 @@
+package com.netflix.governator;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.ProvisionListener;
+import com.netflix.governator.package1.AutoBindSingletonConcrete;
+import com.netflix.governator.package1.AutoBindSingletonInterface;
+import com.netflix.governator.package1.AutoBindSingletonMultiBinding;
+import com.netflix.governator.package1.AutoBindSingletonWithInterface;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class AutoBindSingletonTest {
+    @Test
+    public void confirmBindingsCreatedForAutoBindSinglton() {
+        final Set<Class> created = new HashSet<>();
+        Injector injector = InjectorBuilder.fromModules(
+            new ScanningModuleBuilder()
+                .forPackages("com.netflix.governator.package1")
+                .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
+                .build(),
+            new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bindListener(Matchers.any(), new ProvisionListener() {
+                        @Override
+                        public <T> void onProvision(ProvisionInvocation<T> provision) {
+                            Class<?> type = provision.getBinding().getKey().getTypeLiteral().getRawType();
+                            if (type != null && type.getName().startsWith("com.netflix.governator.package1")) {
+                                created.add(type);
+                            }
+                        }
+                    });
+                }
+            })
+        .createInjector();
+        
+        Assert.assertTrue(created.contains(AutoBindSingletonConcrete.class));
+        
+        injector.getInstance(Key.get(new TypeLiteral<Set<AutoBindSingletonInterface>>() {}));
+        injector.getInstance(Key.get(AutoBindSingletonInterface.class));
+        
+        Assert.assertTrue(created.contains(AutoBindSingletonMultiBinding.class));
+        Assert.assertTrue(created.contains(AutoBindSingletonWithInterface.class));
+    }
+    
+    @Test
+    public void confirmNoBindingsForExcludedClass() {
+        Injector injector = InjectorBuilder.fromModules(
+            new ScanningModuleBuilder()
+                .forPackages("com.netflix.governator.package1")
+                .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
+                .excludeClasses(AutoBindSingletonConcrete.class.getName())
+                .build())
+        .createInjector();
+        
+        Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -1,7 +1,6 @@
 package com.netflix.governator;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.Matchers;
@@ -21,7 +20,7 @@ public class AutoBindSingletonTest {
     @Test
     public void confirmBindingsCreatedForAutoBindSinglton() {
         final Set<Class> created = new HashSet<>();
-        Injector injector = InjectorBuilder.fromModules(
+        try (LifecycleInjector injector = InjectorBuilder.fromModules(
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
                 .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
@@ -40,27 +39,28 @@ public class AutoBindSingletonTest {
                     });
                 }
             })
-        .createInjector();
-        
-        Assert.assertTrue(created.contains(AutoBindSingletonConcrete.class));
-        
-        injector.getInstance(Key.get(new TypeLiteral<Set<AutoBindSingletonInterface>>() {}));
-        injector.getInstance(Key.get(AutoBindSingletonInterface.class));
-        
-        Assert.assertTrue(created.contains(AutoBindSingletonMultiBinding.class));
-        Assert.assertTrue(created.contains(AutoBindSingletonWithInterface.class));
+        .createInjector()) {
+            Assert.assertTrue(created.contains(AutoBindSingletonConcrete.class));
+            
+            injector.getInstance(Key.get(new TypeLiteral<Set<AutoBindSingletonInterface>>() {}));
+            injector.getInstance(Key.get(AutoBindSingletonInterface.class));
+            
+            Assert.assertTrue(created.contains(AutoBindSingletonMultiBinding.class));
+            Assert.assertTrue(created.contains(AutoBindSingletonWithInterface.class));
+            Assert.assertEquals(injector.getInstance(String.class), "AutoBound");
+        }
     }
     
     @Test
     public void confirmNoBindingsForExcludedClass() {
-        Injector injector = InjectorBuilder.fromModules(
+        try (LifecycleInjector injector = InjectorBuilder.fromModules(
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
                 .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
                 .excludeClasses(AutoBindSingletonConcrete.class.getName())
                 .build())
-        .createInjector();
-        
-        Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));
+        .createInjector()) {
+            Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));
+        }
     }
 }

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -23,7 +23,7 @@ public class AutoBindSingletonTest {
         try (LifecycleInjector injector = InjectorBuilder.fromModules(
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
-                .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
+                .addScanner(new AutoBindSingletonAnnotatedClassScanner())
                 .build(),
             new AbstractModule() {
                 @Override
@@ -56,7 +56,7 @@ public class AutoBindSingletonTest {
         try (LifecycleInjector injector = InjectorBuilder.fromModules(
             new ScanningModuleBuilder()
                 .forPackages("com.netflix.governator.package1")
-                .scanForAnnotatedClasses(new AutoBindSingletonAnnotatedClassScanner())
+                .addScanner(new AutoBindSingletonAnnotatedClassScanner())
                 .excludeClasses(AutoBindSingletonConcrete.class.getName())
                 .build())
         .createInjector()) {

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindLazySingleton.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindLazySingleton.java
@@ -1,0 +1,8 @@
+package com.netflix.governator.package1;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton(eager=false)
+public class AutoBindLazySingleton {
+
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindModule.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindModule.java
@@ -1,0 +1,12 @@
+package com.netflix.governator.package1;
+
+import com.google.inject.AbstractModule;
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton
+public class AutoBindModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(String.class).toInstance("AutoBound");
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonConcrete.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonConcrete.java
@@ -1,0 +1,8 @@
+package com.netflix.governator.package1;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton
+public class AutoBindSingletonConcrete {
+
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonInterface.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonInterface.java
@@ -1,0 +1,5 @@
+package com.netflix.governator.package1;
+
+public interface AutoBindSingletonInterface {
+
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonMultiBinding.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonMultiBinding.java
@@ -1,0 +1,11 @@
+package com.netflix.governator.package1;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+import javax.inject.Singleton;
+
+@AutoBindSingleton(multiple=true, value=AutoBindSingletonInterface.class)
+@Singleton
+public class AutoBindSingletonMultiBinding implements AutoBindSingletonInterface {
+
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonWithInterface.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/AutoBindSingletonWithInterface.java
@@ -1,0 +1,8 @@
+package com.netflix.governator.package1;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton(AutoBindSingletonInterface.class)
+public class AutoBindSingletonWithInterface implements AutoBindSingletonInterface {
+
+}

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModule.java
@@ -16,20 +16,6 @@
 
 package com.netflix.governator.guice;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.Set;
-
-import javax.inject.Singleton;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -48,6 +34,20 @@ import com.netflix.governator.annotations.AutoBind;
 import com.netflix.governator.annotations.AutoBindSingleton;
 import com.netflix.governator.guice.lazy.LazySingletonScope;
 import com.netflix.governator.lifecycle.ClasspathScanner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Set;
+
+import javax.inject.Singleton;
 
 class InternalAutoBindModule extends AbstractModule
 {
@@ -165,8 +165,8 @@ class InternalAutoBindModule extends AbstractModule
             AutoBindSingleton annotation = clazz.getAnnotation(AutoBindSingleton.class);
             if ( javax.inject.Provider.class.isAssignableFrom(clazz) )
             {
-                Preconditions.checkState(annotation.value() == AutoBindSingleton.class, "@AutoBindSingleton value cannot be set for Providers");
-                Preconditions.checkState(annotation.baseClass() == AutoBindSingleton.class, "@AutoBindSingleton value cannot be set for Providers");
+                Preconditions.checkState(annotation.value() == Void.class, "@AutoBindSingleton value cannot be set for Providers");
+                Preconditions.checkState(annotation.baseClass() == Void.class, "@AutoBindSingleton value cannot be set for Providers");
                 Preconditions.checkState(!annotation.multiple(), "@AutoBindSingleton(multiple=true) value cannot be set for Providers");
 
                 LOG.info("Installing @AutoBindSingleton " + clazz.getName());
@@ -195,7 +195,7 @@ class InternalAutoBindModule extends AbstractModule
             LOG.info("***** {} should also be annotated with @Singleton to ensure singleton behavior", clazz.getName());
         }
         Class<?> annotationBaseClass = getAnnotationBaseClass(annotation);
-        if ( annotationBaseClass != AutoBindSingleton.class )    // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null
+        if ( annotationBaseClass != Void.class )    // AutoBindSingleton.class is used as a marker to mean "default" because annotation defaults cannot be null
         {
             Object foundBindingClass = searchForBaseClass(clazz, annotationBaseClass, Sets.newHashSet());
             if ( foundBindingClass == null )
@@ -298,9 +298,9 @@ class InternalAutoBindModule extends AbstractModule
     {
         Class<?> annotationValue = annotation.value();
         Class<?> annotationBaseClass = annotation.baseClass();
-        Preconditions.checkState((annotationValue == AutoBindSingleton.class) || (annotationBaseClass == AutoBindSingleton.class), "@AutoBindSingleton cannot have both value and baseClass set");
+        Preconditions.checkState((annotationValue == Void.class) || (annotationBaseClass == Void.class), "@AutoBindSingleton cannot have both value and baseClass set");
 
-        return (annotationBaseClass != AutoBindSingleton.class) ? annotationBaseClass : annotationValue;
+        return (annotationBaseClass != Void.class) ? annotationBaseClass : annotationValue;
     }
 
     private Object searchForBaseClass(Class<?> clazz, Class<?> annotationBaseClass, Set<Object> usedSet)

--- a/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/InternalAutoBindModuleBootstrapModule.java
@@ -53,10 +53,10 @@ public class InternalAutoBindModuleBootstrapModule implements BootstrapModule {
             AutoBindSingleton annotation = clazz.getAnnotation(AutoBindSingleton.class);
             if (Module.class.isAssignableFrom(clazz)) {
                 Preconditions.checkState(
-                        annotation.value() == AutoBindSingleton.class,
+                        annotation.value() == Void.class,
                         "@AutoBindSingleton value cannot be set for Modules");
                 Preconditions.checkState(
-                        annotation.baseClass() == AutoBindSingleton.class,
+                        annotation.baseClass() == Void.class,
                         "@AutoBindSingleton value cannot be set for Modules");
                 Preconditions.checkState(
                         !annotation.multiple(),

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ClasspathScanner.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ClasspathScanner.java
@@ -18,6 +18,16 @@ package com.netflix.governator.lifecycle;
 
 import static org.objectweb.asm.ClassReader.SKIP_CODE;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.netflix.governator.internal.scanner.ClasspathUrlDecoder;
+import com.netflix.governator.internal.scanner.DirectoryClassFilter;
+
+import org.objectweb.asm.ClassReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -29,14 +39,6 @@ import java.util.Enumeration;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
-import org.objectweb.asm.ClassReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 /**
  * Utility to find annotated classes


### PR DESCRIPTION
Added a general ScanningModuleBuilder with support for class annotations on top of which AutoBindSingleton auto binding is implemented.  The resulting module can be installed directly on an injector.

```java
Guice.createInjector(new ScanningModuleBuilder().
     .forPackages("org.example")
     .addScanner(new AutoBindSingletonAnnotatedClassScanner())
     .build()
)
```