### PR TITLE
fix nested lifecycleListener multi-threading issue

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
+++ b/governator-core/src/main/java/com/netflix/governator/LifecycleManager.java
@@ -2,17 +2,12 @@ package com.netflix.governator;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Singleton;
@@ -42,7 +37,7 @@ public final class LifecycleManager {
     private final class ListenerCleanupWorker implements Runnable {
         public void run() {
             try {
-                while (running.get()) {
+                while (state.get().isRunning()) {
                     Reference<? extends LifecycleListener> ref = unreferencedListenersQueue.remove(1000);
                     if (ref != null && ref instanceof SafeLifecycleListener) { 
                         removeListener((SafeLifecycleListener)ref);
@@ -52,40 +47,80 @@ public final class LifecycleManager {
             } 
             catch (InterruptedException e) {
                 LOG.info("LifecycleManager.ListenerCleanupWorker is exiting due to thread interrupt");
+                Thread.interrupted(); // clear interrupted status
             }                
         }
     }
 
     
     private final Set<SafeLifecycleListener> listeners = new LinkedHashSet<>();
-    private final AtomicReference<State> state;
+    private final AtomicReference<State> state = new AtomicReference<>(State.Starting);
     private final ReferenceQueue<LifecycleListener> unreferencedListenersQueue = new ReferenceQueue<>();
-    private volatile Throwable failureReason;
     private final ExecutorService reqQueueExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setDaemon(true).setNameFormat("lifecycle-listener-monitor-%d").build());
-    private final AtomicBoolean running= new AtomicBoolean(true);
+    private volatile Throwable failureReason;
     
     public enum State {
-        Starting,
-        Started,
-        Stopped,
-        Done
+        Starting(true),
+        Started(true),
+        Stopped(false),
+        Done(false);
+        
+        private final boolean running;
+        private State(boolean running) {
+            this.running = running;
+        }
+        public boolean isRunning() {
+            return running;
+        }
     }
     
     public LifecycleManager() {        
         LOG.info("Starting '{}'", this);
-        state = new AtomicReference<>(State.Starting);      
         reqQueueExecutor.submit(new ListenerCleanupWorker());
     }
     
-    private synchronized void removeListener(SafeLifecycleListener listenerRef) {
-        listeners.remove(listenerRef);
+    public synchronized void notifyStarted() {
+        if (state.compareAndSet(State.Starting, State.Started)) {
+            LOG.info("Started '{}'", this);
+            for (LifecycleListener listener : listeners()) {
+                listener.onStarted();
+            }
+        }
     }
     
-    public synchronized void addListener(LifecycleListener listener) {
+    public synchronized void notifyStartFailed(final Throwable t) {
+        // State.Started added here to allow for failure when LifecycleListener.onStarted() is called, post-injector creation
+        if (state.compareAndSet(State.Starting, State.Stopped) || state.compareAndSet(State.Started, State.Stopped)) {
+            LOG.info("Failed start of '{}'", this);
+            this.failureReason = t;
+            shutdown(t);
+        }
+    }
+
+    public synchronized void notifyShutdown() {
+        if (state.compareAndSet(State.Started, State.Stopped)) {
+            LOG.info("Stopping '{}'", this);
+            shutdown(null);
+            state.set(State.Done);
+        }
+    }
+    
+    private void removeListener(SafeLifecycleListener listenerRef) {
+        synchronized(listeners) {
+            listeners.remove(listenerRef);
+        }
+    }
+    
+    public void addListener(LifecycleListener listener) {
         SafeLifecycleListener safeListener = SafeLifecycleListener.wrap(listener, unreferencedListenersQueue);
         
-        if (!listeners.contains(safeListener) && listeners.add(safeListener)) {
-            LOG.info("Adding listener '{}'", safeListener);
+        boolean listenerAdded;
+        synchronized(listeners) {
+            listenerAdded = listeners.add(safeListener);
+        }
+        
+        if (listenerAdded) {
+            LOG.info("Added listener '{}'", safeListener);
             switch (state.get()) {
             case Started:
                 safeListener.onStarted();
@@ -99,41 +134,22 @@ public final class LifecycleManager {
         }
     }
     
-    public synchronized void notifyStarted() {
-        if (state.compareAndSet(State.Starting, State.Started)) {
-            LOG.info("Started '{}'", this);
-            for (LifecycleListener listener : new ArrayList<>(listeners)) {
-                listener.onStarted();
-            }
+    /**
+     * safely returns a copy of listeners in multi-threaded environment
+     * @return
+     */
+    private LinkedList<SafeLifecycleListener> listeners() {
+        synchronized(listeners) {
+            return new LinkedList<>(listeners);
         }
     }
     
-    public synchronized void notifyStartFailed(final Throwable t) {
-        // State.Started added here to allow for failure  when LifecycleListener.onStarted() is called, post-injector creation
-        if (state.compareAndSet(State.Starting, State.Stopped) || state.compareAndSet(State.Started, State.Stopped)) {
-            LOG.info("Failed start of '{}'", this);
-            running.set(false);
-            reqQueueExecutor.shutdown();
-            this.failureReason = t;
-            Iterator<SafeLifecycleListener> shutdownIter = new LinkedList<>(listeners).descendingIterator();
-            while (shutdownIter.hasNext()) {
-                shutdownIter.next().onStopped(t);
-            }
-            listeners.clear();
-        }
-    }
-    
-    public synchronized void notifyShutdown() {
-        if (state.compareAndSet(State.Started, State.Stopped)) {
-            LOG.info("Stopping '{}'", this);
-            Iterator<SafeLifecycleListener> shutdownIter = new LinkedList<>(listeners).descendingIterator();
-            running.set(false);
-            reqQueueExecutor.shutdown();
-            while (shutdownIter.hasNext()) {
-                shutdownIter.next().onStopped(null);
-            }
-            state.set(State.Done);
-            listeners.clear();
+    private void shutdown(final Throwable t) {
+        reqQueueExecutor.shutdown();
+        Iterator<SafeLifecycleListener> shutdownIter = listeners().descendingIterator();
+        listeners.clear();        
+        while (shutdownIter.hasNext()) {
+            shutdownIter.next().onStopped(t);
         }
     }
     

--- a/governator-core/src/test/java/com/netflix/governator/LifecycleManagerTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/LifecycleManagerTest.java
@@ -1,0 +1,84 @@
+package com.netflix.governator;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LifecycleManagerTest {
+    private static Logger logger = LoggerFactory.getLogger(LifecycleManagerTest.class);
+    private LifecycleManager lifecycleManager = new LifecycleManager();
+
+    class LifecycleListener1 implements com.netflix.governator.spi.LifecycleListener {
+        LifecycleListener2 ll2 = new LifecycleListener2();
+        private volatile boolean started;
+        private volatile boolean stopped;
+
+
+        @Override
+        public void onStarted() {
+            logger.info("ll1 - onStarted() called");
+            final CountDownLatch nestingLatch = new CountDownLatch(1);
+            new Thread() {
+                public void run() {
+                    lifecycleManager.addListener(ll2);
+                    nestingLatch.countDown();
+                }
+            }.start();
+            try {
+                nestingLatch.await();
+                started = true;
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            logger.info("ll1 - onStarted() completed");
+        }
+
+        @Override
+        public void onStopped(Throwable error) {
+            stopped = true;
+            logger.info("ll1 - onStopped() called w/error thrown: " + error);
+        }
+
+    }
+
+    class LifecycleListener2 implements com.netflix.governator.spi.LifecycleListener {
+        private volatile boolean started;
+        private volatile boolean stopped;
+
+        @Override
+        public void onStarted() {
+            logger.info("ll2 - onStarted() called");
+            started = true;
+            logger.info("ll2 - onStarted() completed");
+        }
+
+        @Override
+        public void onStopped(Throwable error) {
+            logger.info("ll2 - onStopped() called w/error thrown: " + error);
+            stopped = true;
+        }
+
+    }
+
+    @Test
+    public void testNestedMultithreadedLifecycleListeners() {
+        LifecycleListener1 ll1 = new LifecycleListener1();
+        lifecycleManager.addListener(ll1);
+        Assert.assertFalse(ll1.started);
+        Assert.assertFalse(ll1.ll2.started);
+        Assert.assertFalse(ll1.stopped);
+        Assert.assertFalse(ll1.ll2.stopped);
+        
+        lifecycleManager.notifyStarted();
+        Assert.assertTrue(ll1.started);
+        Assert.assertTrue(ll1.ll2.started);
+        
+        lifecycleManager.notifyShutdown();
+        Assert.assertTrue(ll1.stopped);
+        Assert.assertTrue(ll1.ll2.stopped);
+        
+    }
+}


### PR DESCRIPTION
Problem caused by a LifecycleListener that, when added / started, creates additional LifecycleListeners that would also like to added and started.  This operation works fine, if there's just one thread involved and the synchronized 'LifecycleListener.addListener()' method can be invoked.  If LifecycleListener.onStarted() causes additional LifecycleListeners to be created by different threads, then LifecycleListener.addListener() results in deadlock.

Addressed by locking the 'listeners' collection only when adding / removing an element; invocation of LifecycleListener methods is performed outside of locking using a safe copy of the 'listeners' set.

Also merged the function of the 'Running' field into 'State'; no need for two 'state'-ish indicators in the same class. 