### PR TITLE
Use DefaultResourceConfig instead of PackagesResourceConfig.

### DIFF
--- a/governator-jersey/src/main/java/com/netflix/governator/guice/jersey/GovernatorJerseySupportModule.java
+++ b/governator-jersey/src/main/java/com/netflix/governator/guice/jersey/GovernatorJerseySupportModule.java
@@ -2,11 +2,9 @@ package com.netflix.governator.guice.jersey;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.netflix.governator.guice.jetty.GovernatorServletContainer;
 import com.netflix.governator.providers.AdvisableAnnotatedMethodScanner;
 import com.netflix.governator.providers.ProvidesWithAdvice;
 import com.sun.jersey.api.core.DefaultResourceConfig;
-import com.sun.jersey.api.core.PackagesResourceConfig;
 import com.sun.jersey.api.core.ResourceConfig;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 
@@ -56,7 +54,7 @@ public final class GovernatorJerseySupportModule extends AbstractModule {
     @Singleton
     @Named("governator")
     DefaultResourceConfig getDefaultResourceConfigConfig() {
-        return new PackagesResourceConfig("com.sun.jersey");
+        return new DefaultResourceConfig();
     }
     
     @Singleton


### PR DESCRIPTION
Classpath scanning can be done with the following @Advises

```java
@Advises
@Singleton
@Named("governator")
UnaryOperator<DefaultResourceConfig> getResourceConfig(Config config) {
    return resourceConfig -> {
        resourceConfig.getClasses().addAll(new PackagesResourceConfig("com.example"));
    };
}
```