### PR TITLE
Lifecycle methods restore

### DIFF
--- a/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
@@ -50,7 +50,7 @@ public class ConfigurationLifecycleFeature implements LifecycleFeature {
     @Override
     public List<LifecycleAction> getActionsForType(final Class<?> type) {
         final LifecycleMethods methods = new LifecycleMethods(type);
-        if (methods.fieldsFor(Configuration.class).length > 0) {
+        if (methods.annotatedFields(Configuration.class).length > 0) {
             return Arrays.<LifecycleAction>asList(new LifecycleAction() {
                 @Override
                 public void call(Object obj) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ConfigurationProcessor.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ConfigurationProcessor.java
@@ -138,7 +138,7 @@ class ConfigurationProcessor
             }
             else
             {
-                defaultValue = String.valueOf(LifecycleMethods.fieldGet(field, obj));
+                defaultValue = String.valueOf((Object)LifecycleMethods.fieldGet(field, obj));
             }
 
             String documentationValue;

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/DefaultConfigurationMapper.java
@@ -22,14 +22,14 @@ public class DefaultConfigurationMapper implements ConfigurationMapper {
         /**
          * Map a configuration to any field with @Configuration annotation
          */
-        Field[] configurationFields = methods.fieldsFor(Configuration.class);
+        Field[] configurationFields = methods.annotatedFields(Configuration.class);
         if (configurationFields.length > 0) {
             /**
              * Any field annotated with @ConfigurationVariable will be available for replacement when generating
              * property names
              */
             final Map<String, String> overrides;
-            Field[] configurationVariableFields = methods.fieldsFor(ConfigurationVariable.class);
+            Field[] configurationVariableFields = methods.annotatedFields(ConfigurationVariable.class);
             if (configurationVariableFields.length > 0) {
                 overrides = Maps.newHashMap();
                 for (Field variableField : configurationVariableFields) {

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleManager.java
@@ -275,9 +275,9 @@ public class LifecycleManager implements Closeable, PostInjectorAction
         lifecycleState.set(obj, LifecycleState.POST_CONSTRUCTING);
         methods.methodInvoke(PostConstruct.class, obj);
         
-        Method[] warmUpMethods = methods.methodsFor(WarmUp.class);
+        Method[] warmUpMethods = methods.annotatedMethods(WarmUp.class);
         if (warmUpMethods.length > 0) {
-            Method[] postConstructMethods = methods.methodsFor(PostConstruct.class);
+            Method[] postConstructMethods = methods.annotatedMethods(PostConstruct.class);
             for ( Method warmupMethod : warmUpMethods)
             {
                 boolean skipWarmup = false;

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/LifecycleMethods.java
@@ -270,23 +270,37 @@ public class LifecycleMethods {
     public boolean hasResources() {
         return hasResources;
     }
+    
+    @Deprecated
+    public Collection<Method> methodsFor(Class<? extends Annotation> annotation) {
+        return Arrays.asList(annotatedMethods(annotation));
+    }
 
-    public Method[] methodsFor(Class<? extends Annotation> annotation) {
+    @Deprecated
+    public Collection<Field> fieldsFor(Class<? extends Annotation> annotation) {
+        return Arrays.asList(annotatedFields(annotation));
+    }
+
+    @Deprecated
+    public <T extends Annotation> Collection<T> classAnnotationsFor(Class<T> annotation) {
+        return Arrays.asList(classAnnotations(annotation));
+    }   
+
+    public Method[] annotatedMethods(Class<? extends Annotation> annotation) {
         Method[] methods = methodMap.get(annotation);
         return (methods != null) ? methods : EMPTY_METHODS;
     }
 
-    public Field[] fieldsFor(Class<? extends Annotation> annotation) {
+    public Field[] annotatedFields(Class<? extends Annotation> annotation) {
         Field[] fields = fieldMap.get(annotation);
         return (fields != null) ? fields : EMPTY_FIELDS;
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends Annotation> T[] classAnnotationsFor(Class<T> annotation) {
+    public <T extends Annotation> T[] classAnnotations(Class<T> annotation) {
         Annotation[] annotations = classMap.get(annotation);
         return (annotations != null) ? (T[])annotations : (T[])Array.newInstance(annotation, 0);
     }
-
     
     public void methodInvoke(Class<? extends Annotation> annotation, Object obj) throws Exception {
         if  (methodMap.containsKey(annotation)) {

--- a/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ResourceMapper.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/lifecycle/ResourceMapper.java
@@ -28,37 +28,37 @@ class ResourceMapper {
 
     public void map(Object obj, LifecycleMethods methods) throws Exception {
         if (methods.hasResources()) {
-            for (Field field : methods.fieldsFor(Resources.class)) {
+            for (Field field : methods.annotatedFields(Resources.class)) {
                 Resources resources = field.getAnnotation(Resources.class);
                 for (Resource resource : resources.value()) {
                     setFieldResource(obj, field, resource);
                 }
             }
 
-            for (Field field : methods.fieldsFor(Resource.class)) {
+            for (Field field : methods.annotatedFields(Resource.class)) {
                 Resource resource = field.getAnnotation(Resource.class);
                 setFieldResource(obj, field, resource);
             }
 
-            for (Method method : methods.methodsFor(Resources.class)) {
+            for (Method method : methods.annotatedMethods(Resources.class)) {
                 Resources resources = method.getAnnotation(Resources.class);
                 for (Resource resource : resources.value()) {
                     setMethodResource(obj, method, resource);
                 }
             }
 
-            for (Method method : methods.methodsFor(Resource.class)) {
+            for (Method method : methods.annotatedMethods(Resource.class)) {
                 Resource resource = method.getAnnotation(Resource.class);
                 setMethodResource(obj, method, resource);
             }
 
-            for (Resources resources : methods.classAnnotationsFor(Resources.class)) {
+            for (Resources resources : methods.classAnnotations(Resources.class)) {
                 for (Resource resource : resources.value()) {
                     loadClassResource(resource);
                 }
             }
 
-            for (Resource resource : methods.classAnnotationsFor(Resource.class)) {
+            for (Resource resource : methods.classAnnotations(Resource.class)) {
                 loadClassResource(resource);
             }
         }


### PR DESCRIPTION
these methods restored:

    @Deprecated
    public Collection<Method> methodsFor(Class<? extends Annotation> annotation) {
        return Arrays.asList(annotatedMethods(annotation));
    }

    @Deprecated
    public Collection<Field> fieldsFor(Class<? extends Annotation> annotation) {
        return Arrays.asList(annotatedFields(annotation));
    }

    @Deprecated
    public <T extends Annotation> Collection<T> classAnnotationsFor(Class<T> annotation) {
        return Arrays.asList(classAnnotations(annotation));
    }   
