### PR TITLE
ScanningModuleBuilder AutoBindSingleton dedup fix

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/ScanningModuleBuilder.java
@@ -1,9 +1,8 @@
 package com.netflix.governator;
 
-import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.spi.Elements;
 import com.netflix.governator.internal.scanner.ClasspathUrlDecoder;
 import com.netflix.governator.spi.AnnotatedClassScanner;
 
@@ -141,36 +140,34 @@ public class ScanningModuleBuilder {
     
     public Module build() {
         final Predicate<Class<?>> includeRule = excludeRule.negate();
+
+        List<Consumer<Binder>> consumers = new ArrayList<>();
+        
+        ScannerContext scanner = new ScannerContext();
+        for ( String basePackage : packages )  {
+            scanner.doScan(basePackage, new Consumer<String>() {
+                @Override
+                public void accept(String className) {
+                    try {
+                        Class<?> cls = Class.forName(className, false, classLoader);
+                        if (includeRule.test(cls)) {
+                            for (AnnotatedClassScanner scanner : scanners) {
+                                if (cls.isAnnotationPresent(scanner.annotationClass())) {
+                                    consumers.add(binder -> scanner.applyTo(binder, cls.getAnnotation(scanner.annotationClass()), Key.get(cls)));
+                                }
+                            }
+                        }
+                    } catch (ClassNotFoundException|NoClassDefFoundError e) {
+                        LOG.debug("Error scanning class {}", className, e);
+                    }
+                }
+            });
+        }
         
         // Generate the list of elements here and immediately create a module from them.  This ensures
         // that the class path is canned only once as a Module's configure method may be called multiple
         // times by Guice.
-        return Elements.getModule(Elements.getElements(new AbstractModule() {
-            @Override
-            public void configure() {
-                ScannerContext scanner = new ScannerContext();
-                
-                for ( String basePackage : packages )  {
-                    scanner.doScan(basePackage, new Consumer<String>() {
-                        @Override
-                        public void accept(String className) {
-                            try {
-                                Class<?> cls = Class.forName(className, false, classLoader);
-                                if (includeRule.test(cls)) {
-                                    for (AnnotatedClassScanner scanner : scanners) {
-                                        if (cls.isAnnotationPresent(scanner.annotationClass())) {
-                                            scanner.applyTo(binder(), cls.getAnnotation(scanner.annotationClass()), Key.get(cls));
-                                        }
-                                    }
-                                }
-                            } catch (ClassNotFoundException ignore) {
-                                // This will never happen
-                            }
-                        }
-                    });
-                }
-            }
-        }));
+        return binder -> consumers.forEach(consumer -> consumer.accept(binder));
     }
     
     private class ScannerContext {

--- a/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AutoBindSingletonTest.java
@@ -9,6 +9,7 @@ import com.netflix.governator.package1.AutoBindSingletonConcrete;
 import com.netflix.governator.package1.AutoBindSingletonInterface;
 import com.netflix.governator.package1.AutoBindSingletonMultiBinding;
 import com.netflix.governator.package1.AutoBindSingletonWithInterface;
+import com.netflix.governator.package1.FooModule;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,6 +60,21 @@ public class AutoBindSingletonTest {
                 .addScanner(new AutoBindSingletonAnnotatedClassScanner())
                 .excludeClasses(AutoBindSingletonConcrete.class)
                 .build())
+        .createInjector()) {
+            Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));
+        }
+    }
+    
+    @Test
+    public void confirmModuleDedupingWorksWithScannedClasse() {
+        try (LifecycleInjector injector = InjectorBuilder.fromModules(
+            new ScanningModuleBuilder()
+                .forPackages("com.netflix.governator.package1")
+                .addScanner(new AutoBindSingletonAnnotatedClassScanner())
+                .excludeClasses(AutoBindSingletonConcrete.class)
+                .build(),
+            new FooModule()
+            )
         .createInjector()) {
             Assert.assertNull(injector.getExistingBinding(Key.get(AutoBindSingletonConcrete.class)));
         }

--- a/governator-core/src/test/java/com/netflix/governator/package1/Foo.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/Foo.java
@@ -1,0 +1,18 @@
+package com.netflix.governator.package1;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import javax.inject.Singleton;
+
+public class Foo  extends AbstractModule {
+    @Provides
+    @Singleton
+    Foo getFoo() {
+        return new Foo();
+    }
+
+    @Override
+    protected void configure() {
+    }
+}

--- a/governator-core/src/test/java/com/netflix/governator/package1/FooModule.java
+++ b/governator-core/src/test/java/com/netflix/governator/package1/FooModule.java
@@ -1,0 +1,30 @@
+package com.netflix.governator.package1;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+import javax.inject.Singleton;
+
+@AutoBindSingleton
+public class FooModule extends AbstractModule {
+    @Provides
+    @Singleton
+    Foo getFoo() {
+        return new Foo();
+    }
+
+    @Override
+    protected void configure() {
+    }
+    
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return getClass().equals(obj.getClass());
+    }
+}


### PR DESCRIPTION
- Fix module deducing for AutoBindSingleton modules picked up by ScanningModuleBuilder
- When picking up classes during class path scanning ignore (and log as debug) NoClassDefFoundError exceptions