### PR TITLE
ElementVisitor to output a warning about toInstance bindings

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/InjectorBuilder.java
+++ b/governator-core/src/main/java/com/netflix/governator/InjectorBuilder.java
@@ -1,13 +1,5 @@
 package com.netflix.governator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -21,6 +13,14 @@ import com.netflix.governator.spi.ModuleTransformer;
 import com.netflix.governator.visitors.IsNotStaticInjectionVisitor;
 import com.netflix.governator.visitors.KeyTracingVisitor;
 import com.netflix.governator.visitors.WarnOfStaticInjectionVisitor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Simple DSL on top of Guice through which an injector may be created using a series
@@ -109,6 +109,36 @@ public final class InjectorBuilder {
             String message = element.acceptVisitor(visitor);
             if (message != null) {
                 LOG.debug(message);
+            }
+        }
+        return this;
+    }
+    
+    /**
+     * Iterator through all elements of the current module and write the output of the
+     * ElementVisitor to the logger at info level.  'null' responses are ignored
+     * @param visitor
+     */
+    public InjectorBuilder infoEachElement(ElementVisitor<String> visitor) {
+        for (Element element : Elements.getElements(module)) {
+            String message = element.acceptVisitor(visitor);
+            if (message != null) {
+                LOG.info(message);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Iterator through all elements of the current module and write the output of the
+     * ElementVisitor to the logger at warn level.  'null' responses are ignored
+     * @param visitor
+     */
+    public InjectorBuilder warnEachElement(ElementVisitor<String> visitor) {
+        for (Element element : Elements.getElements(module)) {
+            String message = element.acceptVisitor(visitor);
+            if (message != null) {
+                LOG.warn(message);
             }
         }
         return this;

--- a/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
@@ -1,0 +1,25 @@
+package com.netflix.governator.visitors;
+
+import com.google.inject.Binding;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.DefaultElementVisitor;
+import com.google.inject.spi.InstanceBinding;
+import com.google.inject.spi.ProviderInstanceBinding;
+
+public class WarnOfToInstanceInjectionVisitor extends DefaultElementVisitor<String> { 
+    public <T> String visit(Binding<T> binding) {
+        return binding.acceptTargetVisitor(new DefaultBindingTargetVisitor<T, String>() {
+            public String visit(InstanceBinding<? extends T> instanceBinding) {
+                return String.format("toInstance() at %s can force undesireable static initialization.  " +
+                        "Consider replacing with an @Provides method instead.",
+                        instanceBinding.getSource());
+            }
+
+            public String visit(ProviderInstanceBinding<? extends T> providerInstanceBinding) {
+                return String.format("toInstance() at %s can force undesireable static initialization.  " +
+                        "Consider replacing with an @Provides method instead.",
+                        providerInstanceBinding.getSource());
+            }            
+        });
+    }
+}

--- a/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
@@ -5,7 +5,14 @@ import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.DefaultElementVisitor;
 import com.google.inject.spi.InstanceBinding;
 
-public class WarnOfToInstanceInjectionVisitor extends DefaultElementVisitor<String> { 
+/*
+ * Specialized {@link DefaultElementVisitor} that formats a warning for any toInstance() binding.  
+ * Use this with {@link InjectorBuilder#forEachElement} to identify situations where toInstance() bindings 
+ * are used.  The assertion here is that toInstance bindings are an indicator of provisioning being
+ * done outside of Guice and could involve static initialization that violates ordering guarantees
+ * of a DI framework.  The recommendation is to replace toInstance() bindings with @Provides methods.
+ */
+public final class WarnOfToInstanceInjectionVisitor extends DefaultElementVisitor<String> { 
     public <T> String visit(Binding<T> binding) {
         return binding.acceptTargetVisitor(new DefaultBindingTargetVisitor<T, String>() {
             public String visit(InstanceBinding<? extends T> instanceBinding) {

--- a/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/visitors/WarnOfToInstanceInjectionVisitor.java
@@ -4,7 +4,6 @@ import com.google.inject.Binding;
 import com.google.inject.spi.DefaultBindingTargetVisitor;
 import com.google.inject.spi.DefaultElementVisitor;
 import com.google.inject.spi.InstanceBinding;
-import com.google.inject.spi.ProviderInstanceBinding;
 
 public class WarnOfToInstanceInjectionVisitor extends DefaultElementVisitor<String> { 
     public <T> String visit(Binding<T> binding) {
@@ -14,12 +13,6 @@ public class WarnOfToInstanceInjectionVisitor extends DefaultElementVisitor<Stri
                         "Consider replacing with an @Provides method instead.",
                         instanceBinding.getSource());
             }
-
-            public String visit(ProviderInstanceBinding<? extends T> providerInstanceBinding) {
-                return String.format("toInstance() at %s can force undesireable static initialization.  " +
-                        "Consider replacing with an @Provides method instead.",
-                        providerInstanceBinding.getSource());
-            }            
         });
     }
 }

--- a/governator-core/src/test/java/com/netflix/governator/InjectorBuilderTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/InjectorBuilderTest.java
@@ -1,21 +1,24 @@
 package com.netflix.governator;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.inject.Inject;
+import com.google.inject.AbstractModule;
+import com.google.inject.spi.Element;
+import com.netflix.governator.visitors.BindingTracingVisitor;
+import com.netflix.governator.visitors.KeyTracingVisitor;
+import com.netflix.governator.visitors.ModuleSourceTracingVisitor;
+import com.netflix.governator.visitors.WarnOfToInstanceInjectionVisitor;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.mockito.Mockito;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.spi.Element;
-import com.netflix.governator.visitors.BindingTracingVisitor;
-import com.netflix.governator.visitors.KeyTracingVisitor;
-import com.netflix.governator.visitors.ModuleSourceTracingVisitor;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
 
 public class InjectorBuilderTest {
  
@@ -69,6 +72,22 @@ public class InjectorBuilderTest {
             })
             .traceEachElement(new BindingTracingVisitor())
             .createInjector();
+    }
+    
+    @Test
+    public void testForEachBinding() {
+        Consumer<String> consumer = Mockito.mock(Consumer.class);
+        InjectorBuilder
+            .fromModule(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(String.class).toInstance("Hello world");
+                }
+            })
+            .forEachElement(new WarnOfToInstanceInjectionVisitor(), consumer)
+            .createInjector();
+        
+        Mockito.verify(consumer, Mockito.times(1)).accept(Mockito.anyString());
     }
     
     @Test


### PR DESCRIPTION
toInstance() bindings risk forcing static initialization of code from the configure() method of a Guice module, which can have undersireable side effects for static bridges.  Adding ``.infoEachElement(new WarnOfToInstanceInjectionVisitor())`` to the InjectorBuilder can be used to identify toInstance() bindings.

```java
InjectorBuilder.fromModules(...)
   .infoEachElement(new WarnOfToInstanceInjectionVisitor())
   .createInjector();
```