### PR TITLE
Enable provision metrics by default

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/ProvisionDebugModule.java
+++ b/governator-core/src/main/java/com/netflix/governator/ProvisionDebugModule.java
@@ -15,8 +15,6 @@ public final class ProvisionDebugModule extends SingletonModule {
         // We do a static injection here to make sure the listener gets registered early.  Otherwise,
         // if the injector fails before it's instantiated no logging will be done
         binder().requestStaticInjection(ProvisionDebugModule.class);
-        
-        bind(ProvisionMetrics.class).to(SimpleProvisionMetrics.class);
     }
     
     @Override

--- a/governator-core/src/main/java/com/netflix/governator/ProvisionMetrics.java
+++ b/governator-core/src/main/java/com/netflix/governator/ProvisionMetrics.java
@@ -12,15 +12,12 @@ import com.google.inject.Key;
  * for the first initialization of all objects.  Note that no call
  * will be made for singletons that are being injected but have 
  * already been instantiated.
- * 
- * @author elandau
  */
-@ImplementedBy(NullProvisionMetrics.class)
+@ImplementedBy(SimpleProvisionMetrics.class)
 public interface ProvisionMetrics {
     
     /**
      * Node used to track metrics for an object that has been provisioned
-     * @author elandau
      */
     public static interface Element {
         public Key<?> getKey();
@@ -34,8 +31,6 @@ public interface ProvisionMetrics {
     
     /**
      * Visitor API for traversing nodes
-     * @author elandau
-     *
      */
     public static interface Visitor {
         void visit(Element element);

--- a/governator-core/src/test/java/com/netflix/governator/ProvisionMetricsModuleTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/ProvisionMetricsModuleTest.java
@@ -16,7 +16,25 @@ import javax.inject.Singleton;
 
 public class ProvisionMetricsModuleTest {
     @Test
-    public void defaultMetricsAreEmpty() {
+    public void disableMetrics() {
+        try (LifecycleInjector injector = InjectorBuilder.fromModule(
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ProvisionMetrics.class).to(NullProvisionMetrics.class);
+                    }
+                })
+            .createInjector()) {
+            
+            ProvisionMetrics metrics = injector.getInstance(ProvisionMetrics.class);
+            LoggingProvisionMetricsVisitor visitor = new LoggingProvisionMetricsVisitor();
+            metrics.accept(visitor);
+            Assert.assertTrue(visitor.getElementCount() == 0);
+        }
+    }
+    
+    @Test
+    public void confirmDedupWorksWithOverride() {
         try (LifecycleInjector injector = InjectorBuilder.fromModule(
                 new AbstractModule() {
                     @Override
@@ -30,13 +48,12 @@ public class ProvisionMetricsModuleTest {
                     protected void configure() {
                     }
                 })
-            .traceEachElement(new ProvisionListenerTracingVisitor())
             .createInjector()) {
             
             ProvisionMetrics metrics = injector.getInstance(ProvisionMetrics.class);
             LoggingProvisionMetricsVisitor visitor = new LoggingProvisionMetricsVisitor();
             metrics.accept(visitor);
-            Assert.assertTrue(visitor.getElementCount() == 0);
+            Assert.assertTrue(visitor.getElementCount() != 0);
         }
     }
     


### PR DESCRIPTION
Metrics can be disable by adding the following binding

```java
bind(ProvisionMetrics.class).to(NullProvisionMetrics.class);
```