### PR TITLE
Change Grapher#graph roots check to be isEmpty instead of null

### DIFF
--- a/governator-legacy/src/main/java/com/netflix/governator/guice/Grapher.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/guice/Grapher.java
@@ -150,7 +150,7 @@ public class Grapher
         GraphvizGrapher renderer = localInjector.getInstance(GraphvizGrapher.class);
         renderer.setOut(out);
         renderer.setRankdir("TB");
-        if (roots != null) {
+        if (!roots.isEmpty()) {
             renderer.graph(injector, roots);
         }
         renderer.graph(injector);


### PR DESCRIPTION
Was getting a empty roots graph when using the Grapher class. `roots` can never be null, though it can be empty. Changed the graph method to check `isEmpty` on roots instead of null.