### PR TITLE
Make ConfigurationLifecycleFeature lazy

### DIFF
--- a/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import com.google.inject.ProvisionException;
@@ -32,15 +33,15 @@ import com.netflix.governator.lifecycle.LifecycleMethods;
 @Singleton
 public class ConfigurationLifecycleFeature implements LifecycleFeature {
     
-    private ConfigurationMapper mapper;
-    private ConfigurationProvider configurationProvider;
-    private ConfigurationDocumentation configurationDocumentation;
+    private Provider<ConfigurationMapper> mapper;
+    private Provider<ConfigurationProvider> configurationProvider;
+    private Provider<ConfigurationDocumentation> configurationDocumentation;
 
     @Inject
     public void initialize(
-            ConfigurationMapper mapper, 
-            ConfigurationProvider configurationProvider, 
-            ConfigurationDocumentation configurationDocumentation
+            Provider<ConfigurationMapper> mapper, 
+            Provider<ConfigurationProvider> configurationProvider, 
+            Provider<ConfigurationDocumentation> configurationDocumentation
             ) {
         this.mapper = mapper;
         this.configurationDocumentation = configurationDocumentation;
@@ -58,7 +59,7 @@ public class ConfigurationLifecycleFeature implements LifecycleFeature {
                         throw new ProvisionException("Trying to map fields of type " + type.getName() + " before ConfigurationLifecycleFeature was fully initialized by the injector");
                     }
                     try {
-                        mapper.mapConfiguration(configurationProvider, configurationDocumentation, obj, methods);
+                        mapper.get().mapConfiguration(configurationProvider.get(), configurationDocumentation.get(), obj, methods);
                     } catch (Exception e) {
                         throw new ProvisionException("Failed to map configuration for type " + type.getName(), e);
                     }

--- a/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
+++ b/governator-legacy/src/main/java/com/netflix/governator/ConfigurationLifecycleFeature.java
@@ -1,6 +1,5 @@
 package com.netflix.governator;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,19 +32,29 @@ import com.netflix.governator.lifecycle.LifecycleMethods;
 @Singleton
 public class ConfigurationLifecycleFeature implements LifecycleFeature {
     
-    private Provider<ConfigurationMapper> mapper;
-    private Provider<ConfigurationProvider> configurationProvider;
-    private Provider<ConfigurationDocumentation> configurationDocumentation;
-
+    public static class Mapper {
+        private ConfigurationMapper mapper;
+        private ConfigurationProvider configurationProvider;
+        private ConfigurationDocumentation configurationDocumentation;
+        
+        Mapper(ConfigurationMapper mapper, 
+              ConfigurationProvider configurationProvider, 
+              ConfigurationDocumentation configurationDocumentation) {
+            this.mapper = mapper;
+            this.configurationProvider = configurationProvider;
+            this.configurationDocumentation = configurationDocumentation;
+        }
+        
+        private void mapConfiguration(Object obj, LifecycleMethods methods) throws Exception {
+            mapper.mapConfiguration(configurationProvider, configurationDocumentation, obj, methods);
+        }
+    }
+    
+    private volatile Provider<Mapper> mapper;
+    
     @Inject
-    public void initialize(
-            Provider<ConfigurationMapper> mapper, 
-            Provider<ConfigurationProvider> configurationProvider, 
-            Provider<ConfigurationDocumentation> configurationDocumentation
-            ) {
-        this.mapper = mapper;
-        this.configurationDocumentation = configurationDocumentation;
-        this.configurationProvider = configurationProvider;
+    public void initialize(Provider<Mapper> state) {
+        this.mapper = state;
     }
     
     @Override
@@ -54,12 +63,13 @@ public class ConfigurationLifecycleFeature implements LifecycleFeature {
         if (methods.annotatedFields(Configuration.class).length > 0) {
             return Arrays.<LifecycleAction>asList(new LifecycleAction() {
                 @Override
-                public void call(Object obj) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+                public void call(Object obj) throws Exception {
                     if (mapper == null) {
                         throw new ProvisionException("Trying to map fields of type " + type.getName() + " before ConfigurationLifecycleFeature was fully initialized by the injector");
                     }
+                    
                     try {
-                        mapper.get().mapConfiguration(configurationProvider.get(), configurationDocumentation.get(), obj, methods);
+                        mapper.get().mapConfiguration(obj, methods);
                     } catch (Exception e) {
                         throw new ProvisionException("Failed to map configuration for type " + type.getName(), e);
                     }
@@ -73,7 +83,7 @@ public class ConfigurationLifecycleFeature implements LifecycleFeature {
     
     @Override
     public String toString() {
-        return "Configuration";
+        return "ConfigurationLifecycleFeature[]";
     }
 
 }


### PR DESCRIPTION
ConfigurationLifecycleFeature is initialized early as part of a static initialization path for framework components.  Since it injects ConfigurationProvider it can trigger early initialization of framework components (such as archaius) that are also dependent on static initialization for early instantiation.  This PR changes the behavior such that ConfigurationProvider is lazily instantiated when it is actually used.
