### PR TITLE
Fixing README - fixing the governator-tomcat code snippet

### DIFF
--- a/governator-core/README.md
+++ b/governator-core/README.md
@@ -138,7 +138,7 @@ public class StartServer extends GovernatorServletContextListener
                     bind(MyResource.class).asEagerSingleton();
                 }
             }
-        );
+        ).createInjector();
     }
 }
 ```


### PR DESCRIPTION
The method createInjector() should call .createInjector() on InjectorBuilder to return the Injector instance.