### PR TITLE
Update jackson-databind dependency to 2.9.8

### DIFF
--- a/governator-legacy/build.gradle
+++ b/governator-legacy/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile    project(':governator-api')
     compile    project(':governator-core')
     compile    'org.ow2.asm:asm:5.0.4'
-    compile    'com.fasterxml.jackson.core:jackson-databind:2.4.3'
+    compile    'com.fasterxml.jackson.core:jackson-databind:2.9.8'
 
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'com.tngtech.java:junit-dataprovider:1.11.0'


### PR DESCRIPTION
jackson-databind 2.4.3 contains vulnerabilities and any projects depending on com.netflix.governator:governator will show them when running dependency check reports. Upgrading jackson-databind 2.9.8 does not seem to cause any issues and fixes the problem.

![jackson-databind-2 4 3-vulnerabilities](https://user-images.githubusercontent.com/1674873/52210243-5ba45f00-287e-11e9-93cb-2927d4f971fd.png)
![jackson-databind-2 4 3-vulnerabilities-cw-184](https://user-images.githubusercontent.com/1674873/52210248-60691300-287e-11e9-9fb6-0918d79b8f7c.png)
![jackson-databind-2 4 3-vulnerabilities-cwe-502](https://user-images.githubusercontent.com/1674873/52210251-6232d680-287e-11e9-90f7-58ceafcf4315.png)
