### PR TITLE
fix memory leak for OptionalBinder with PreDestroy

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
@@ -250,15 +250,14 @@ public class PreDestroyMonitor implements AutoCloseable {
             return rv;
         }
 
-        /*
-         * add a soft-reference ManagedInstanceAction to cleanupActions deque. Cleanup triggered only at injector
-         * shutdown if referent has not yet been collected.
-         * 
+        /**
+         * Do nothing. When using OptionalBinder this will end up getting called each time the
+         * type is injected resulting in a memory leak if a cleanup action is added.
          */
         @Override
         public Boolean visitNoScoping() {
-            cleanupActions.addFirst(
-                    new ManagedInstanceAction(new SoftReference<Object>(injectee), context, lifecycleActions));
+            //cleanupActions.addFirst(
+            //        new ManagedInstanceAction(new SoftReference<Object>(injectee), context, lifecycleActions));
             return true;
         }
     }

--- a/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
@@ -1,0 +1,111 @@
+package com.netflix.governator.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.OptionalBinder;
+import com.netflix.governator.lifecycle.LifecycleManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Provider;
+
+public class TestLifecycleInjector {
+
+  public void checkCleanup(Module m) throws Exception {
+    // If the PreDestroy method for the object is called more than once, then it means
+    // there is a memory leak because we have registered multiple ManagedInstanceActions
+    // in the PreDestroyMonitor
+    Injector injector = LifecycleInjector.builder()
+        .withModules(m)
+        .build()
+        .createInjector();
+
+    LifecycleManager mgr = injector.getInstance(LifecycleManager.class);
+    mgr.start();
+
+    PreDestroyOnce obj = injector.getInstance(PreDestroyOnce.class);
+    for (int i = 0; i < 1000; ++i) {
+      PreDestroyOnce tmp = injector.getInstance(PreDestroyOnce.class);
+      Assert.assertSame(obj, tmp);
+    }
+
+    mgr.close();
+
+    Assert.assertTrue(obj.isClosed());
+  }
+
+  @Test
+  public void providedBindingPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+      }
+
+      @Singleton
+      @Provides
+      public PreDestroyOnce providesObj() {
+        return new PreDestroyOnceImpl();
+      }
+    });
+  }
+
+  @Test
+  public void optionalBindingPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class)
+            .setDefault()
+            .to(PreDestroyOnceImpl.class)
+            .in(Scopes.SINGLETON);
+      }
+    });
+  }
+
+  @Test
+  public void optionalProviderBindingPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class)
+            .setDefault()
+            .toProvider(PreDestroyOnceProvider.class)
+            .in(Scopes.SINGLETON);
+      }
+    });
+  }
+
+  private interface PreDestroyOnce {
+    boolean isClosed();
+  }
+
+  @Singleton
+  private static class PreDestroyOnceImpl implements PreDestroyOnce {
+
+    private boolean closed = false;
+
+    @Override public boolean isClosed() {
+      return closed;
+    }
+
+    @PreDestroy
+    public void close() {
+      Assert.assertFalse(closed);
+      closed = true;
+    }
+  }
+
+  @Singleton
+  private static class PreDestroyOnceProvider implements Provider<PreDestroyOnce> {
+
+    @Override
+    public PreDestroyOnce get() {
+      return new PreDestroyOnceImpl();
+    }
+  }
+}

--- a/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LifeCycleFeaturesOnLegacyBuilderTest.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/lifecycle/LifeCycleFeaturesOnLegacyBuilderTest.java
@@ -83,7 +83,8 @@ public class LifeCycleFeaturesOnLegacyBuilderTest {
             return "LifecycleSubject@" + System.identityHashCode(this) + '[' + name + ']';
         }
     }
-    
+
+    @Singleton
     static class UsesNullable {
         private AtomicBoolean preDestroyed = new AtomicBoolean(false);
         private LifecycleSubject subject;


### PR DESCRIPTION
If OptionalBinder is used with a type that has a PreDestroy
method, then PreDestroyMonitor will add a cleanup action each
time that type is injected. If this happens a lot, e.g. using
it with `RequestScoped`, then it can quickly fill up the heap
and cause OOM.

@tcellucci The `optional*` test cases reproduce the issue. Trying
your suggestion of just ignoring bindings with no scope seems to
have worked in that it passed the tests (I needed to add a scope to
one class for some Nullable tests). I don't know if it is the best way
to fix this issue, but it should avoid the memory leak.

/cc @vfilanovsky 