### PR TITLE
Pre destroy no scope bug

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
@@ -7,6 +7,9 @@ import com.google.inject.Provider;
 import com.google.inject.Scope;
 import com.google.inject.Scopes;
 import com.google.inject.spi.BindingScopingVisitor;
+import com.google.inject.spi.DefaultBindingTargetVisitor;
+import com.google.inject.spi.Dependency;
+import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.util.Providers;
 import com.netflix.governator.LifecycleAction;
 import com.netflix.governator.ManagedInstanceAction;
@@ -17,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.annotation.Annotation;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
-import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +27,8 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -35,13 +39,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Monitors managed instances and invokes cleanup actions when they become unreferenced
+ * Monitors managed instances and invokes cleanup actions when they become
+ * unreferenced
  * 
  * @author tcellucci
  *
  */
 public class PreDestroyMonitor implements AutoCloseable {
     private static Logger LOGGER = LoggerFactory.getLogger(PreDestroyMonitor.class);
+
     private static class ScopeCleanupMarker {
         static final Key<ScopeCleanupMarker> MARKER_KEY = Key.get(ScopeCleanupMarker.class);
         // simple id uses identity equality
@@ -62,7 +68,8 @@ public class PreDestroyMonitor implements AutoCloseable {
     }
 
     static final class ScopeCleaner implements Provider<ScopeCleanupMarker> {
-        ConcurrentMap<Object, ScopeCleanupAction> scopedCleanupActions = new ConcurrentHashMap<>(BinaryConstant.I14_16384);
+        ConcurrentMap<Object, ScopeCleanupAction> scopedCleanupActions = new ConcurrentHashMap<>(
+                BinaryConstant.I14_16384);
         ReferenceQueue<ScopeCleanupMarker> markerReferenceQueue = new ReferenceQueue<>();
         final ExecutorService reqQueueExecutor = Executors.newSingleThreadExecutor(
                 new ThreadFactoryBuilder().setDaemon(true).setNameFormat("predestroy-monitor-%d").build());
@@ -107,7 +114,8 @@ public class PreDestroyMonitor implements AutoCloseable {
         }
 
         /**
-         * Processes unreferenced markers from the referenceQueue, until the 'running' flag is false or interrupted
+         * Processes unreferenced markers from the referenceQueue, until the 'running'
+         * flag is false or interrupted
          * 
          */
         final class ScopedCleanupWorker implements Runnable {
@@ -133,18 +141,43 @@ public class PreDestroyMonitor implements AutoCloseable {
 
     }
 
-    private Deque<Callable<Void>> cleanupActions = new ConcurrentLinkedDeque<>();
+    private Map<Object, UnscopedCleanupAction> cleanupActions = new WeakHashMap<>();
     private ScopeCleaner scopeCleaner = new ScopeCleaner();
-
-    Map<Class<? extends Annotation>, Scope> scopeBindings;
+    private Map<Class<? extends Annotation>, Scope> scopeBindings;
 
     public PreDestroyMonitor(Map<Class<? extends Annotation>, Scope> scopeBindings) {
         this.scopeBindings = new HashMap<>(scopeBindings);
     }
 
     public <T> boolean register(T destroyableInstance, Binding<T> binding, Iterable<LifecycleAction> action) {
-        return scopeCleaner.isRunning() ? binding.acceptScopingVisitor(
-                new ManagedInstanceScopingVisitor(destroyableInstance, binding.getSource(), action)) : false;
+        if (scopeCleaner.isRunning()) {
+            boolean visitNoScope = Optional
+                    .ofNullable(binding.acceptTargetVisitor(new DefaultBindingTargetVisitor<T, Boolean>() {
+                        @Override
+                        public Boolean visit(ProviderInstanceBinding<? extends T> providerInstanceBinding) {
+                            if (providerInstanceBinding.getDependencies().size() == 1) {
+                                Dependency<?> parentDep = providerInstanceBinding.getDependencies().iterator().next();
+                                if (parentDep.getParameterIndex() == -1) {
+                                    if (parentDep.getKey().getTypeLiteral()
+                                            .equals(providerInstanceBinding.getKey().getTypeLiteral())) {
+                                        /*
+                                         * this destroyableInstance was obtained from a Provider that _implicitly_
+                                         * depends only on another binding's destroyableInstance of the exact same type
+                                         * (i.e., dependency is not an injected parameter). Do not add new lifecycle
+                                         * method handler for this destroyableInstance if it is in 'no_scope'
+                                         */
+                                        return false;
+                                    }
+                                }
+                            }
+                            return true;
+
+                        }
+                    })).orElse(true);
+            return binding.acceptScopingVisitor(
+                    new ManagedInstanceScopingVisitor(destroyableInstance, binding.getSource(), action, visitNoScope));
+        }
+        return false;
     }
 
     /*
@@ -152,14 +185,15 @@ public class PreDestroyMonitor implements AutoCloseable {
      */
     public <T> boolean register(T destroyableInstance, Object context, Iterable<LifecycleAction> action) {
         return scopeCleaner.isRunning()
-                ? new ManagedInstanceScopingVisitor(destroyableInstance, context, action).visitEagerSingleton() : false;
+                ? new ManagedInstanceScopingVisitor(destroyableInstance, context, action).visitEagerSingleton()
+                : false;
     }
 
     /**
-     * allows late-binding of scopes to PreDestroyMonitor, useful if more than one Injector contributes scope bindings
+     * allows late-binding of scopes to PreDestroyMonitor, useful if more than one
+     * Injector contributes scope bindings
      * 
-     * @param bindings
-     *            additional annotation-to-scope bindings to add
+     * @param bindings additional annotation-to-scope bindings to add
      */
     public void addScopeBindings(Map<Class<? extends Annotation>, Scope> bindings) {
         if (scopeCleaner.isRunning()) {
@@ -172,24 +206,28 @@ public class PreDestroyMonitor implements AutoCloseable {
      */
     @Override
     public void close() throws Exception {
-        if (scopeCleaner.close()) { // executor thread to exit processing loop
-            LOGGER.info("closing PreDestroyMonitor...");
-
-            for (Callable<Void> action : cleanupActions) {
-                action.call();
+        LOGGER.info("closing PreDestroyMonitor...");
+        if (scopeCleaner.close()) { // executor thread to exit processing loop            
+            synchronized(cleanupActions) {
+                List<Map.Entry<Object, UnscopedCleanupAction>> actions = new ArrayList<>(cleanupActions.entrySet());
+                Collections.sort(actions, (a,b)->Long.compare(b.getValue().ordinal, a.getValue().ordinal));
+                for (Map.Entry<Object, UnscopedCleanupAction> action : actions) {
+                    action.getValue().call(action.getKey());
+                }
+                actions.clear();
+                cleanupActions.clear();
             }
-            cleanupActions.clear();
             scopeBindings.clear();
             scopeBindings = Collections.emptyMap();
-        }
-        else {
+        } else {
             LOGGER.warn("PreDestroyMonitor.close() invoked but instance is not running");
         }
     }
 
     /**
-     * visits bindingScope of managed instance to set up an appropriate strategy for cleanup, adding actions to either
-     * the scopedCleanupActions map or cleanupActions list. Returns true if cleanup actions were added, false if no
+     * visits bindingScope of managed instance to set up an appropriate strategy for
+     * cleanup, adding actions to either the scopedCleanupActions map or
+     * cleanupActions list. Returns true if cleanup actions were added, false if no
      * cleanup strategy was selected.
      * 
      */
@@ -197,12 +235,19 @@ public class PreDestroyMonitor implements AutoCloseable {
         private final Object injectee;
         private final Object context;
         private final Iterable<LifecycleAction> lifecycleActions;
+        private final boolean processNoScope;
 
         private ManagedInstanceScopingVisitor(Object injectee, Object context,
                 Iterable<LifecycleAction> lifecycleActions) {
+            this(injectee, context, lifecycleActions, true);
+        }
+
+        private ManagedInstanceScopingVisitor(Object injectee, Object context,
+                Iterable<LifecycleAction> lifecycleActions, boolean processNoScope) {
             this.injectee = injectee;
             this.context = context;
             this.lifecycleActions = lifecycleActions;
+            this.processNoScope = processNoScope;
         }
 
         /*
@@ -210,22 +255,23 @@ public class PreDestroyMonitor implements AutoCloseable {
          * 
          */
         @Override
-        public Boolean visitEagerSingleton() {                    
+        public Boolean visitEagerSingleton() {
             return visitScope(Scopes.SINGLETON);
         }
 
         /*
-         * use ScopeCleanupMarker dereferencing strategy to detect scope closure, add new entry to scopedCleanupActions
-         * map
+         * use ScopeCleanupMarker dereferencing strategy to detect scope closure, add
+         * new entry to scopedCleanupActions map
          * 
          */
         @Override
         public Boolean visitScope(Scope scope) {
             final Provider<ScopeCleanupMarker> scopedMarkerProvider;
-            if (scope.equals(Scopes.SINGLETON) || (scope instanceof AbstractScope && ((AbstractScope)scope).isSingletonScope())) {
+            if (scope.equals(Scopes.SINGLETON)
+                    || (scope instanceof AbstractScope && ((AbstractScope) scope).isSingletonScope())) {
                 scopedMarkerProvider = Providers.of(scopeCleaner.singletonMarker);
             } else {
-                scopedMarkerProvider = scope.scope(ScopeCleanupMarker.MARKER_KEY, scopeCleaner);                
+                scopedMarkerProvider = scope.scope(ScopeCleanupMarker.MARKER_KEY, scopeCleaner);
             }
             ScopeCleanupMarker marker = scopedMarkerProvider.get();
             marker.getCleanupAction().add(scopedMarkerProvider, new ManagedInstanceAction(injectee, lifecycleActions));
@@ -242,8 +288,7 @@ public class PreDestroyMonitor implements AutoCloseable {
             boolean rv;
             if (scope != null) {
                 rv = visitScope(scope);
-            }
-            else {
+            } else {
                 LOGGER.warn("no scope binding found for annotation " + scopeAnnotation.getName());
                 rv = false;
             }
@@ -251,20 +296,55 @@ public class PreDestroyMonitor implements AutoCloseable {
         }
 
         /**
-         * Do nothing. When using OptionalBinder this will end up getting called each time the
-         * type is injected resulting in a memory leak if a cleanup action is added.
+         * Do nothing. When using OptionalBinder this will end up getting called each
+         * time the type is injected resulting in a memory leak if a cleanup action is
+         * added.
          */
         @Override
         public Boolean visitNoScoping() {
-            //cleanupActions.addFirst(
-            //        new ManagedInstanceAction(new SoftReference<Object>(injectee), context, lifecycleActions));
+            if (processNoScope) {
+                synchronized (cleanupActions) {
+                    cleanupActions.put(injectee, new UnscopedCleanupAction(context, lifecycleActions));
+                }
+                LOGGER.debug("predestroy action registered for unscoped instance {} from {}", injectee, context);
+            }
             return true;
         }
     }
 
+    private static final class UnscopedCleanupAction implements LifecycleAction, Comparable<UnscopedCleanupAction> {
+        private volatile static long instanceCounter = 0;
+        private final long ordinal;
+        private final Object context;
+        private final Iterable<LifecycleAction> lifecycleActions;
+
+        public UnscopedCleanupAction(Object context, Iterable<LifecycleAction> lifecycleActions) {
+            this.context = context;
+            this.lifecycleActions = lifecycleActions;
+            this.ordinal = instanceCounter++;
+        }
+
+        @Override
+        public void call(Object obj) {
+            lifecycleActions.forEach(action -> {
+                try {
+                    action.call(obj);
+                } catch (Exception e) {
+                    LOGGER.error("PreDestroy call failed for {} from {}", action, context, e);
+                }
+            });
+        }
+
+        @Override
+        public int compareTo(UnscopedCleanupAction o) {
+            return Long.compare(ordinal, o.ordinal);
+        }
+    }
+
     /**
-     * Runnable that weakly references a scopeCleanupMarker and strongly references a list of delegate runnables. When
-     * the marker is unreferenced, delegates will be invoked in the reverse order of addition.
+     * Runnable that weakly references a scopeCleanupMarker and strongly references
+     * a list of delegate runnables. When the marker is unreferenced, delegates will
+     * be invoked in the reverse order of addition.
      */
     private static final class ScopeCleanupAction extends WeakReference<ScopeCleanupMarker>
             implements Callable<Void>, Comparable<ScopeCleanupAction> {

--- a/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
@@ -30,8 +30,8 @@ public class TestLifecycleInjector {
     LifecycleManager mgr = injector.getInstance(LifecycleManager.class);
     mgr.start();
 
-    Object[] obj = new Object[1000];
-    for (int i = 0; i < 1000; ++i) {
+    Object[] obj = new Object[25];
+    for (int i = 0; i < 25; ++i) {
       obj[i] = injector.getInstance(type);
     }
 
@@ -228,7 +228,7 @@ public class TestLifecycleInjector {
   }
 
   /**
-   * registers LinkedProviderBinding in 'No Scope' 1000 times
+   * registers LinkedProviderBinding in Singleton scope 1 time
    */
   @Test
   public void testSingletonOptionalPreDestroy() throws Exception {

--- a/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
@@ -62,7 +62,7 @@ public class TestLifecycleInjector {
     }, PreDestroyOnce.class);
   }
 
-  /** registers ProviderInstanceBinding with 'no scope' 1000 times */
+  /** registers ProviderInstanceBinding with 'no scope' 25 times */
   @Test
   public void providedInstanceBindingUnscopedPreDestroy() throws Exception {
     checkCleanup(new AbstractModule() {
@@ -163,7 +163,7 @@ public class TestLifecycleInjector {
   }
 
   /**
-   * registers ConstructorBinding in 'No Scope' 1000 times
+   * registers ConstructorBinding in 'No Scope' 25 times
    * @throws Exception
    */
   @Test
@@ -195,7 +195,7 @@ public class TestLifecycleInjector {
   }
 
   /**
-   * registers ProviderMethodProviderInstanceBinding in 'No Scope' 1000 times
+   * registers ProviderMethodProviderInstanceBinding in 'No Scope' 25 times
    */
   @Test
   public void testUnscopedProviderPreDestroy() throws Exception {
@@ -213,7 +213,7 @@ public class TestLifecycleInjector {
   }
 
  /**
-   * registers LinkedProviderBinding in 'No Scope' 1000 times
+   * registers LinkedProviderBinding in 'No Scope' 25 times
    */
    @Test
   public void testOptionalPreDestroy() throws Exception {

--- a/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
@@ -1,6 +1,7 @@
 package com.netflix.governator.guice;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -11,36 +12,43 @@ import com.netflix.governator.lifecycle.LifecycleManager;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Optional;
+
 import javax.annotation.PreDestroy;
 import javax.inject.Provider;
 
 public class TestLifecycleInjector {
 
-  public void checkCleanup(Module m) throws Exception {
-    // If the PreDestroy method for the object is called more than once, then it means
-    // there is a memory leak because we have registered multiple ManagedInstanceActions
-    // in the PreDestroyMonitor
-    Injector injector = LifecycleInjector.builder()
-        .withModules(m)
-        .build()
-        .createInjector();
+  public <T extends PreDestroyOnce> void checkCleanup(Module m, Class<T> type) throws Exception {
+    /*
+     * If the PreDestroy method for the object is called more than once, then it
+     * means there is a memory leak because we have registered multiple
+     * ManagedInstanceActions in the PreDestroyMonitor
+     */
+    Injector injector = LifecycleInjector.builder().withModules(m).build().createInjector();
 
     LifecycleManager mgr = injector.getInstance(LifecycleManager.class);
     mgr.start();
 
-    PreDestroyOnce obj = injector.getInstance(PreDestroyOnce.class);
+    Object[] obj = new Object[1000];
     for (int i = 0; i < 1000; ++i) {
-      PreDestroyOnce tmp = injector.getInstance(PreDestroyOnce.class);
-      Assert.assertSame(obj, tmp);
+      obj[i] = injector.getInstance(type);
     }
 
     mgr.close();
 
-    Assert.assertTrue(obj.isClosed());
+    for (Object o : obj) {
+      T t = (T) o;
+      Assert.assertTrue(t.isClosed());
+      int count = t.getCount();
+      Assert.assertEquals("count equals " + count, 1, count);
+    }
+
   }
 
+  /** registers ProviderInstanceBinding with Singleton scope 1 time */
   @Test
-  public void providedBindingPreDestroy() throws Exception {
+  public void providedInstanceBindingPreDestroy() throws Exception {
     checkCleanup(new AbstractModule() {
       @Override
       protected void configure() {
@@ -48,61 +56,280 @@ public class TestLifecycleInjector {
 
       @Singleton
       @Provides
-      public PreDestroyOnce providesObj() {
+      public PreDestroyOnce providesObj(String param1) {
         return new PreDestroyOnceImpl();
       }
-    });
+    }, PreDestroyOnce.class);
   }
 
+  /** registers ProviderInstanceBinding with 'no scope' 1000 times */
+  @Test
+  public void providedInstanceBindingUnscopedPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+      }
+
+      @Provides
+      public PreDestroyOnce providesObj(String name) {
+        return new PreDestroyOnceImpl();
+      }
+    }, PreDestroyOnce.class);
+  }
+
+  /**
+   * registers ConstructorBindingImpl with Singleton scope 1 time
+   */
   @Test
   public void optionalBindingPreDestroy() throws Exception {
     checkCleanup(new AbstractModule() {
       @Override
       protected void configure() {
-        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class)
-            .setDefault()
-            .to(PreDestroyOnceImpl.class)
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault().to(PreDestroyOnceImpl.class)
             .in(Scopes.SINGLETON);
       }
-    });
+    }, PreDestroyOnce.class);
   }
 
+  /**
+   * registers ConstructorBindingImpl with Singleton scope 1 time
+   */
+  @Test
+  public void optionalBindingUnscopedPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault().to(PreDestroyOnceImpl.class);
+      }
+    }, PreDestroyOnce.class);
+  }
+
+  /**
+   * registers LinkedProviderBinding in Singleton scope 1 time
+   */
   @Test
   public void optionalProviderBindingPreDestroy() throws Exception {
     checkCleanup(new AbstractModule() {
       @Override
       protected void configure() {
-        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class)
-            .setDefault()
-            .toProvider(PreDestroyOnceProvider.class)
-            .in(Scopes.SINGLETON);
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault()
+            .toProvider(PreDestroyOnceProvider.class).in(Scopes.SINGLETON);
       }
-    });
+    }, PreDestroyOnce.class);
   }
+
+  /**
+   * registers InstanceBinding in Singleton scope 1 time
+   */
+  @Test
+  public void optionalProviderBindingUnscopedPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault()
+            .toProvider(PreDestroyOnceProvider.class);
+
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setBinding()
+            .toInstance(new PreDestroyOnceImpl());
+
+      }
+    }, PreDestroyOnce.class);
+  }
+
+/**
+ * registers InstanceBinding in Singleton scope 1 time
+ */
+@Test
+  public void providedInstancePreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault()
+            .toInstance(new PreDestroyOnceImpl());
+      }
+    }, PreDestroyOnce.class);
+  }
+
+  /**
+   * registers ConstructorBinding in Singleton scope 1 time
+   */
+  @Test
+  public void testAutomaticBindingPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+      }
+    }, PreDestroyOnceImpl.class);
+  }
+
+  /**
+   * registers ConstructorBinding in 'No Scope' 1000 times
+   * @throws Exception
+   */
+  @Test
+  public void testAutomaticBindingUnboundPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+      }
+    }, PreDestroyOnceProtoImpl.class);
+  }
+
+  /**
+   * registers ProviderMethodProviderInstanceBinding in Singleton scope 1 times
+   */
+  @Test
+  public void testSingletonProviderPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+
+      }
+
+      @Provides
+      @Singleton
+      public PreDestroyOnce providesObj(String name) {
+        return new PreDestroyOnceImpl();
+      }
+    }, JavaxSingletonConsumer.class);
+  }
+
+  /**
+   * registers ProviderMethodProviderInstanceBinding in 'No Scope' 1000 times
+   */
+  @Test
+  public void testUnscopedProviderPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+
+      }
+
+      @Provides
+      public PreDestroyOnce providesObj(String name) {
+        return new PreDestroyOnceImpl();
+      }
+    }, JavaxSingletonConsumer.class);
+  }
+
+ /**
+   * registers LinkedProviderBinding in 'No Scope' 1000 times
+   */
+   @Test
+  public void testOptionalPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault()
+            .toProvider(PreDestroyOnceProvider.class);
+      }
+
+    }, JavaxOptionalConsumer.class);
+  }
+
+  /**
+   * registers LinkedProviderBinding in 'No Scope' 1000 times
+   */
+  @Test
+  public void testSingletonOptionalPreDestroy() throws Exception {
+    checkCleanup(new AbstractModule() {
+      @Override
+      protected void configure() {
+        OptionalBinder.newOptionalBinder(binder(), PreDestroyOnce.class).setDefault()
+            .toProvider(PreDestroyOnceProvider.class).asEagerSingleton();
+      }
+
+    }, JavaxOptionalConsumer.class);
+  }
+
 
   private interface PreDestroyOnce {
     boolean isClosed();
+
+    int getCount();
+  }
+
+  private static class JavaxSingletonConsumer implements PreDestroyOnce {
+    private final PreDestroyOnce delegate;
+
+    @Inject
+    JavaxSingletonConsumer(Provider<PreDestroyOnce> provider) {
+      this.delegate = provider.get();
+    }
+
+    public boolean isClosed() {
+      return delegate.isClosed();
+    }
+
+    public int getCount() {
+      return delegate.getCount();
+    }
+  }
+
+  private static class JavaxOptionalConsumer implements PreDestroyOnce {
+    private final PreDestroyOnce delegate;
+
+    @Inject
+    JavaxOptionalConsumer(Optional<PreDestroyOnce> provider) {
+      this.delegate = provider.orElse(null);
+    }
+
+    public boolean isClosed() {
+      return delegate.isClosed();
+    }
+
+    public int getCount() {
+      return delegate.getCount();
+    }
   }
 
   @Singleton
   private static class PreDestroyOnceImpl implements PreDestroyOnce {
 
     private boolean closed = false;
+    private int counter = 0;
 
-    @Override public boolean isClosed() {
+    @Override
+    public boolean isClosed() {
       return closed;
     }
 
     @PreDestroy
     public void close() {
-      Assert.assertFalse(closed);
+      ++counter;
       closed = true;
+    }
+
+    @Override
+    public int getCount() {
+      return counter;
+    }
+  }
+
+  private static class PreDestroyOnceProtoImpl implements PreDestroyOnce {
+
+    private boolean closed = false;
+    private int counter = 0;
+
+    @Override
+    public boolean isClosed() {
+      return closed;
+    }
+
+    @PreDestroy
+    public void close() {
+      ++counter;
+      closed = true;
+    }
+
+    @Override
+    public int getCount() {
+      return counter;
     }
   }
 
   @Singleton
   private static class PreDestroyOnceProvider implements Provider<PreDestroyOnce> {
-
     @Override
     public PreDestroyOnce get() {
       return new PreDestroyOnceImpl();

--- a/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
+++ b/governator-legacy/src/test/java/com/netflix/governator/guice/TestLifecycleInjector.java
@@ -30,17 +30,17 @@ public class TestLifecycleInjector {
     LifecycleManager mgr = injector.getInstance(LifecycleManager.class);
     mgr.start();
 
-    Object[] obj = new Object[25];
+    Object[] objs = new Object[25];
     for (int i = 0; i < 25; ++i) {
-      obj[i] = injector.getInstance(type);
+      objs[i] = injector.getInstance(type);
     }
 
     mgr.close();
 
-    for (Object o : obj) {
+    for (Object o : objs) {
       T t = (T) o;
       Assert.assertTrue(t.isClosed());
-      int count = t.getCount();
+      int count = t.getPreDestroyCallCount();
       Assert.assertEquals("count equals " + count, 1, count);
     }
 
@@ -246,7 +246,7 @@ public class TestLifecycleInjector {
   private interface PreDestroyOnce {
     boolean isClosed();
 
-    int getCount();
+    int getPreDestroyCallCount();
   }
 
   private static class JavaxSingletonConsumer implements PreDestroyOnce {
@@ -261,8 +261,8 @@ public class TestLifecycleInjector {
       return delegate.isClosed();
     }
 
-    public int getCount() {
-      return delegate.getCount();
+    public int getPreDestroyCallCount() {
+      return delegate.getPreDestroyCallCount();
     }
   }
 
@@ -278,8 +278,8 @@ public class TestLifecycleInjector {
       return delegate.isClosed();
     }
 
-    public int getCount() {
-      return delegate.getCount();
+    public int getPreDestroyCallCount() {
+      return delegate.getPreDestroyCallCount();
     }
   }
 
@@ -301,7 +301,7 @@ public class TestLifecycleInjector {
     }
 
     @Override
-    public int getCount() {
+    public int getPreDestroyCallCount() {
       return counter;
     }
   }
@@ -323,7 +323,7 @@ public class TestLifecycleInjector {
     }
 
     @Override
-    public int getCount() {
+    public int getPreDestroyCallCount() {
       return counter;
     }
   }


### PR DESCRIPTION
what is the problem: fix a long-standing memory leak caused by unscoped instances injected via Provider. The situation commonly occurs when a provider is declared for a type that implements AutoCloseable or is annotated with '@PreDestroy'.  At runtime, the injected instances are bound with 'no scope' by Guice, leading to a large number of cleanup actions pointing to potentially the same object.  The memory leak consists of the cleanup actions themselves, rather than the provided instance.

what is the fix: this PR adds specific handling of ProvidedInstanceBindings, to ensure that cleanup actions are not created every time a provider-sourced instance is injected.  It also refactors the PreDestroyMonitor class to hold any cleanup actions for 'unscoped' instances in a WeakHashMap, to ensure that only one cleanup action exists for an unscoped provisioned instance. 

The PR also introduces some code to log the number of unscoped instances present at shutdown, and shows where these instances were bound to the injector.