### PR TITLE
fix assisted inject predestroy

### DIFF
--- a/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
+++ b/governator-core/src/main/java/com/netflix/governator/internal/PreDestroyMonitor.java
@@ -1,7 +1,6 @@
 package com.netflix.governator.internal;
 
 import com.google.common.collect.MapMaker;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Binding;
 import com.google.inject.Key;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -257,6 +255,8 @@ public class PreDestroyMonitor implements AutoCloseable {
             if (scope.equals(Scopes.SINGLETON)
                     || (scope instanceof AbstractScope && ((AbstractScope) scope).isSingletonScope())) {
                 scopedMarkerProvider = Providers.of(scopeCleaner.singletonMarker);
+            } else if (scope.equals(Scopes.NO_SCOPE)) {
+                return visitNoScoping();
             } else {
                 scopedMarkerProvider = scope.scope(ScopeCleanupMarker.MARKER_KEY, scopeCleaner);
             }

--- a/governator-core/src/test/java/com/netflix/governator/AssistedInjectPreDestroyTest.java
+++ b/governator-core/src/test/java/com/netflix/governator/AssistedInjectPreDestroyTest.java
@@ -1,0 +1,95 @@
+package com.netflix.governator;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import com.google.inject.Module;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.netflix.governator.InjectorBuilder;
+import com.netflix.governator.LifecycleInjector;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AssistedInjectPreDestroyTest {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Test
+    public void testAssistedInject() throws Exception {
+        Module assistedInjectModule = new FactoryModuleBuilder()
+                .implement(AnInterestingClient.class, InterestingClientImpl.class)
+                .build(InterestingClientFactory.class);
+
+        final AnInterestingClient interestingClient;
+        try (LifecycleInjector injector = InjectorBuilder.fromModule(assistedInjectModule).createInjector()) {
+            interestingClient = injector.getInstance(InterestingClientFactory.class).create("something");
+
+            log.info("Init is all done, I'll pretend to be doing something for a bit");
+            Thread.sleep(1_000L);
+            Assert.assertFalse(interestingClient.isClosed());
+
+            log.info("Kicking the GC to see if it triggers unintended cleanups");
+            System.gc();
+            Thread.sleep(1_000L);
+            Assert.assertFalse(interestingClient.isClosed());
+
+            log.info("Just woke up again, about to close shop");
+            interestingClient.setOkToClose();
+        }
+        // injector is closed by try block exit above, which triggers PreDestroy /
+        // AutoCloseable methods
+        Assert.assertTrue(interestingClient.isClosed());
+        log.info("Done closing shop, bye");
+    }
+}
+
+interface AnInterestingClient {
+    void setOkToClose();
+
+    boolean isClosed();
+}
+
+class InterestingClientImpl implements AnInterestingClient {
+    private static final Logger logger = LoggerFactory.getLogger(InterestingClientImpl.class);
+    private final AtomicBoolean isOkToClose = new AtomicBoolean(false);
+    private final AtomicBoolean closedBeforeExpected = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    @Inject
+    InterestingClientImpl(@Assisted String aParameter) {
+    }
+
+    @Override
+    public void setOkToClose() {
+        if (closedBeforeExpected.get()) {
+            throw new IllegalStateException("Someone called close before we were ready!");
+        }
+        isOkToClose.set(true);
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed.get();
+    }
+
+    @PreDestroy
+    public void close() {
+        closed.set(true);
+        if (!isOkToClose.get()) {
+            closedBeforeExpected.set(true);
+            logger.info("Someone called close() on me ({}) and I'm mad about it", this);
+
+        } else {
+            logger.info("Someone called close() on me ({}) and I'm ok with that", this);
+        }
+    }
+}
+
+interface InterestingClientFactory {
+    AnInterestingClient create(@Assisted String aParameter);
+}


### PR DESCRIPTION
**what's the problem:**
instances provisioned by Guice using assisted injection that also declare lifecycle methods (such as @PreDestroy annotated methods or implement AutoCloseable) are not handled correctly.  Governator invokes lifecycle methods on these instances immediately rather than waiting for them to be dereferenced or for the injector to be closed.

**what's the fix:**
the fix is to add specific handling of the NO_SCOPE scope built into Guice. This 'scope' is essentially a no-op that does not maintain any reference to instances it creates.  The behavior defeats Governator's scope cleanup logic, such that instances are immediately cleaned up.  The fix for this problem is essentially a two-liner to delegate NO_SCOPE-scoped instances to an existing codepath in `ManagedInstanceScopingVisitor`.
